### PR TITLE
add tests for usage info

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -84,7 +84,7 @@ func (p *Parser) WriteHelp(w io.Writer) {
 			if spec.short != "" {
 				left += ", " + synopsis(spec, "-"+spec.short)
 			}
-			fmt.Print(left)
+			fmt.Fprint(w, left)
 			if spec.help != "" {
 				if len(left)+2 < colWidth {
 					fmt.Fprint(w, strings.Repeat(" ", colWidth-len(left)))

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,46 @@
+package arg
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteUsage(t *testing.T) {
+	expectedUsage := "usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]] \n"
+
+	expectedHelp := `usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]] 
+
+positional arguments:
+  input
+  output
+
+options:
+  --verbose, -v          verbosity level
+  --dataset DATASET      dataset to use
+  --optimize OPTIMIZE, -O OPTIMIZE
+                         optimization level
+`
+	var args struct {
+		Input    string   `arg:"positional"`
+		Output   []string `arg:"positional"`
+		Verbose  bool     `arg:"-v,help:verbosity level"`
+		Dataset  string   `arg:"help:dataset to use"`
+		Optimize int      `arg:"-O,help:optimization level"`
+	}
+	p, err := NewParser(&args)
+	require.NoError(t, err)
+
+	os.Args[0] = "example"
+
+	var usage bytes.Buffer
+	p.WriteUsage(&usage)
+	assert.Equal(t, expectedUsage, usage.String())
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}


### PR DESCRIPTION
This pr adds unittests for the printing of usage and help information. It also fixes a bug in which some usage information was not printed to the buffer.