### PR TITLE
Remove excess trailing whitespace from Usage generation

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -27,10 +27,12 @@ func (p *Parser) WriteUsage(w io.Writer) {
 		}
 	}
 
-	fmt.Fprintf(w, "usage: %s ", filepath.Base(os.Args[0]))
+	fmt.Fprintf(w, "usage: %s", filepath.Base(os.Args[0]))
 
 	// write the option component of the usage message
 	for _, spec := range options {
+		// prefix with a space
+		fmt.Fprint(w, " ")
 		if !spec.required {
 			fmt.Fprint(w, "[")
 		}
@@ -38,18 +40,18 @@ func (p *Parser) WriteUsage(w io.Writer) {
 		if !spec.required {
 			fmt.Fprint(w, "]")
 		}
-		fmt.Fprint(w, " ")
 	}
 
 	// write the positional component of the usage message
 	for _, spec := range positionals {
+		// prefix with a space
+		fmt.Fprint(w, " ")
 		up := strings.ToUpper(spec.long)
 		if spec.multiple {
 			fmt.Fprintf(w, "[%s [%s ...]]", up, up)
 		} else {
 			fmt.Fprint(w, up)
 		}
-		fmt.Fprint(w, " ")
 	}
 	fmt.Fprint(w, "\n")
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestWriteUsage(t *testing.T) {
-	expectedUsage := "usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]] \n"
+	expectedUsage := "usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]\n"
 
-	expectedHelp := `usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]] 
+	expectedHelp := `usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]
 
 positional arguments:
   input


### PR DESCRIPTION
When looking at `usage_test.go` I noticed that the tests started to fail because my editor removed the trailing whitespace from the usage line in `expectedHelp`.

This PR is to remove that excess whitespace from the usage line by prefixing each argument with a space rather than postfixing it.

We were able to do this easily since the `"usage: %s "` format had a trailing whitespace as well.