### PR TITLE
Display help text for positional arguments

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -68,11 +68,24 @@ func (p *Parser) WriteHelp(w io.Writer) {
 
 	p.WriteUsage(w)
 
+	// the width of the left column
+	const colWidth = 25
+
 	// write the list of positionals
 	if len(positionals) > 0 {
 		fmt.Fprint(w, "\npositional arguments:\n")
 		for _, spec := range positionals {
-			fmt.Fprintf(w, "  %s\n", spec.long)
+			left := "  " + spec.long
+			fmt.Fprint(w, left)
+			if spec.help != "" {
+				if len(left)+2 < colWidth {
+					fmt.Fprint(w, strings.Repeat(" ", colWidth-len(left)))
+				} else {
+					fmt.Fprint(w, "\n"+strings.Repeat(" ", colWidth))
+				}
+				fmt.Fprint(w, spec.help)
+			}
+			fmt.Fprint(w, "\n")
 		}
 	}
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -16,7 +16,7 @@ func TestWriteUsage(t *testing.T) {
 
 positional arguments:
   input
-  output
+  output                 positional output
 
 options:
   --verbose, -v          verbosity level
@@ -27,7 +27,7 @@ options:
 `
 	var args struct {
 		Input    string   `arg:"positional"`
-		Output   []string `arg:"positional"`
+		Output   []string `arg:"positional,help:positional output"`
 		Verbose  bool     `arg:"-v,help:verbosity level"`
 		Dataset  string   `arg:"help:dataset to use"`
 		Optimize int      `arg:"-O,help:optimization level"`
@@ -41,6 +41,29 @@ options:
 	p.WriteUsage(&usage)
 	assert.Equal(t, expectedUsage, usage.String())
 
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}
+
+func TestUsageLongPositionalWithHelp(t *testing.T) {
+	expectedHelp := `usage: example VERYLONGPOSITIONALWITHHELP
+
+positional arguments:
+  verylongpositionalwithhelp
+                         this positional argument is very long
+
+options:
+  --help, -h             display this help and exit
+`
+	var args struct {
+		VeryLongPositionalWithHelp string `arg:"positional,help:this positional argument is very long"`
+	}
+
+	p, err := NewParser(&args)
+	require.NoError(t, err)
+
+	os.Args[0] = "example"
 	var help bytes.Buffer
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())


### PR DESCRIPTION
This pull request is dependent on #7, so please only review the HEAD commit https://github.com/alexflint/go-arg/commit/086eff38e4a73d3b1a7eff25cfb7d8be3b0d646f

This PR is to add support for the `help:` tag on positional arguments. It uses the same column width that is being used for options.

Here is the example generated from `usage_test.go`

```go
var args struct {
	Input    string   `arg:"positional"`
	Output   []string `arg:"positional,help:positional output"`
	Verbose  bool     `arg:"-v,help:verbosity level"`
	Dataset  string   `arg:"help:dataset to use"`
	Optimize int      `arg:"-O,help:optimization level"`
}
```

```
usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]

positional arguments:
  input
  output                 positional output

options:
  --verbose, -v          verbosity level
  --dataset DATASET      dataset to use
  --optimize OPTIMIZE, -O OPTIMIZE
                         optimization level
```