### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,41 @@ Input: src.txt
 Output: [x.out y.out z.out]
 ```
 
+### Environment variables
+
+```go
+var args struct {
+	Workers int `arg:"env"`
+}
+arg.MustParse(&args)
+fmt.Println("Workers:", args.Workers)
+```
+
+```
+$ WORKERS=4 ./example
+Workers: 4
+```
+
+```
+$ WORKERS=4 ./example --workers=6
+Workers: 6
+```
+
+You can also override the name of the environment variable:
+
+```go
+var args struct {
+	Workers int `arg:"env:NUM_WORKERS"`
+}
+arg.MustParse(&args)
+fmt.Println("Workers:", args.Workers)
+```
+
+```
+$ NUM_WORKERS=4 ./example
+Workers: 4
+```
+
 ### Usage strings
 ```go
 var args struct {

--- a/parse_test.go
+++ b/parse_test.go
@@ -357,3 +357,53 @@ func TestMustParse(t *testing.T) {
 	assert.Equal(t, "bar", args.Foo)
 	assert.NotNil(t, parser)
 }
+
+func TestEnvironmentVariable(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env"`
+	}
+	os.Setenv("FOO", "bar")
+	os.Args = []string{"example"}
+	MustParse(&args)
+	assert.Equal(t, "bar", args.Foo)
+}
+
+func TestEnvironmentVariableOverrideName(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env:BAZ"`
+	}
+	os.Setenv("BAZ", "bar")
+	os.Args = []string{"example"}
+	MustParse(&args)
+	assert.Equal(t, "bar", args.Foo)
+}
+
+func TestEnvironmentVariableOverrideArgument(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env"`
+	}
+	os.Setenv("FOO", "bar")
+	os.Args = []string{"example", "--foo", "baz"}
+	MustParse(&args)
+	assert.Equal(t, "baz", args.Foo)
+}
+
+func TestEnvironmentVariableError(t *testing.T) {
+	var args struct {
+		Foo int `arg:"env"`
+	}
+	os.Setenv("FOO", "bar")
+	os.Args = []string{"example"}
+	err := Parse(&args)
+	assert.Error(t, err)
+}
+
+func TestEnvironmentVariableRequired(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env,required"`
+	}
+	os.Setenv("FOO", "bar")
+	os.Args = []string{"example"}
+	MustParse(&args)
+	assert.Equal(t, "bar", args.Foo)
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestWriteUsage(t *testing.T) {
-	expectedUsage := "usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] INPUT [OUTPUT [OUTPUT ...]]\n"
+	expectedUsage := "usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--workers WORKERS] INPUT [OUTPUT [OUTPUT ...]]\n"
 
-	expectedHelp := `usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] INPUT [OUTPUT [OUTPUT ...]]
+	expectedHelp := `usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--workers WORKERS] INPUT [OUTPUT [OUTPUT ...]]
 
 positional arguments:
   input
@@ -26,6 +26,8 @@ options:
   --optimize OPTIMIZE, -O OPTIMIZE
                          optimization level
   --ids IDS              Ids
+  --workers WORKERS, -w WORKERS
+                         number of workers to start
   --help, -h             display this help and exit
 `
 	var args struct {
@@ -37,6 +39,7 @@ options:
 		Dataset  string   `arg:"help:dataset to use"`
 		Optimize int      `arg:"-O,help:optimization level"`
 		Ids      []int64  `arg:"help:Ids"`
+		Workers  int      `arg:"-w,env:WORKERS,help:number of workers to start"`
 	}
 	args.Name = "Foo Bar"
 	args.Value = 42


### PR DESCRIPTION
I decided to take a stab at #2 and this is what I came up with.

Adding in a new tag `env`, if provided, `go-arg` will look for an environment variable to preload the argument from. Using the tag on it's own `arg:"env"` by default it will use `strings.ToUpper(field.Name)` of the argument, or else you can override the name of the environment variable via `arg:"env:ENV_VAR"`.