### PR TITLE
Write usage message to stderr on error

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-// Fail prints usage information to stdout and exits with non-zero status
+// Fail prints usage information to stderr and exits with non-zero status
 func (p *Parser) Fail(msg string) {
-	p.WriteUsage(os.Stdout)
+	p.WriteUsage(os.Stderr)
 	fmt.Println("error:", msg)
 	os.Exit(-1)
 }


### PR DESCRIPTION
Hi! I really like your library, great work!

I saw that the fail message when something goes wrong with parsing is printed to stdout, I don't know if this is just preference, but I prefer to output that on stderr. I've got some backing here http://courses.cms.caltech.edu/cs11/material/general/usage.html but it's up to you to decide.
As I see it it's an error, even if it contains usage information also.

This patch does:
When the parsing of parameters/flags fails eg. when a required flag is
missing, print the usage statement and error to stderr instead of
stdout.

Tests are passing.