### PR TITLE
Built in version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ fmt.Printf("Fetching the following IDs from %s: %q", args.Database, args.IDs)
 Fetching the following IDs from foo: [1 2 3]
 ```
 
+### Using the version flag
+```go
+var args struct {
+	Database string
+	IDs      []int64
+}
+arg.SetVersion("1.0.0")
+arg.MustParse(&args)
+```
+
+```shell
+./example --version
+example 1.0.0
+```
+
 ### Built in flags
 
 There is two built in flags, help `-h, --help` and version `--version`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ fmt.Printf("Fetching the following IDs from %s: %q", args.Database, args.IDs)
 Fetching the following IDs from foo: [1 2 3]
 ```
 
+### Built in flags
+
+There is two built in flags, help `-h, --help` and version `--version`.
+Help outputs the usage.
+Version outputs the version set with `SetVersion` if it is set, otherwise it's 
+an unrecognized flag.
+
 ### Installation
 
 ```shell

--- a/parse.go
+++ b/parse.go
@@ -28,12 +28,16 @@ var ErrHelp = errors.New("help requested by user")
 // ErrVersion indicates that --version were provided
 var ErrVersion = errors.New("version requested by user")
 
-// Version set by the application, shown with the --version flag
-var Version = ""
+// Default parser used by high level functions
+var defaultParser *Parser
 
 // SetVersion sets the version available for --version flag
 func SetVersion(version string) {
-	Version = version
+	if defaultParser == nil {
+		defaultParser = &Parser{Version: version}
+	} else {
+		defaultParser.SetVersion(version)
+	}
 }
 
 // MustParse processes command line arguments and exits upon failure
@@ -68,11 +72,58 @@ func Parse(dest ...interface{}) error {
 
 // Parser represents a set of command line options with destination values
 type Parser struct {
-	spec []*spec
+	spec    []*spec
+	Version string
 }
 
 // NewParser constructs a parser from a list of destination structs
 func NewParser(dests ...interface{}) (*Parser, error) {
+	var p *Parser
+	if defaultParser == nil {
+		p = &Parser{}
+	} else {
+		p = defaultParser
+	}
+	err := p.setSpecs(dests...)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// Parse processes the given command line option, storing the results in the field
+// of the structs from which NewParser was constructed
+func (p *Parser) Parse(args []string) error {
+	// If -h or --help were specified then print usage
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return ErrHelp
+		}
+		if p.Version != "" && arg == "--version" {
+			return ErrVersion
+		}
+		if arg == "--" {
+			break
+		}
+	}
+
+	// Process all command line arguments
+	err := process(p.spec, args)
+	if err != nil {
+		return err
+	}
+
+	// Validate
+	return validate(p.spec)
+}
+
+// SetVersion sets the version outputted with --version
+func (p *Parser) SetVersion(version string) {
+	p.Version = version
+}
+
+// setSpecs defines the specs from a list of destination structs
+func (p *Parser) setSpecs(dests ...interface{}) error {
 	var specs []*spec
 	for _, dest := range dests {
 		v := reflect.ValueOf(dest)
@@ -113,7 +164,7 @@ func NewParser(dests ...interface{}) (*Parser, error) {
 			case reflect.Array, reflect.Chan, reflect.Func, reflect.Interface,
 				reflect.Map, reflect.Ptr, reflect.Struct,
 				reflect.Complex64, reflect.Complex128:
-				return nil, fmt.Errorf("%s.%s: %s fields are not supported", t.Name(), field.Name, scalarType.Kind())
+				return fmt.Errorf("%s.%s: %s fields are not supported", t.Name(), field.Name, scalarType.Kind())
 			}
 
 			// Specify that it is a bool for usage
@@ -135,7 +186,7 @@ func NewParser(dests ...interface{}) (*Parser, error) {
 						spec.long = key[2:]
 					case strings.HasPrefix(key, "-"):
 						if len(key) != 2 {
-							return nil, fmt.Errorf("%s.%s: short arguments must be one character only", t.Name(), field.Name)
+							return fmt.Errorf("%s.%s: short arguments must be one character only", t.Name(), field.Name)
 						}
 						spec.short = key[1:]
 					case key == "required":
@@ -145,40 +196,15 @@ func NewParser(dests ...interface{}) (*Parser, error) {
 					case key == "help":
 						spec.help = value
 					default:
-						return nil, fmt.Errorf("unrecognized tag '%s' on field %s", key, tag)
+						return fmt.Errorf("unrecognized tag '%s' on field %s", key, tag)
 					}
 				}
 			}
 			specs = append(specs, &spec)
 		}
 	}
-	return &Parser{spec: specs}, nil
-}
-
-// Parse processes the given command line option, storing the results in the field
-// of the structs from which NewParser was constructed
-func (p *Parser) Parse(args []string) error {
-	// If -h or --help were specified then print usage
-	for _, arg := range args {
-		if arg == "-h" || arg == "--help" {
-			return ErrHelp
-		}
-		if Version != "" && arg == "--version" {
-			return ErrVersion
-		}
-		if arg == "--" {
-			break
-		}
-	}
-
-	// Process all command line arguments
-	err := process(p.spec, args)
-	if err != nil {
-		return err
-	}
-
-	// Validate
-	return validate(p.spec)
+	p.spec = specs
+	return nil
 }
 
 // process goes through arguments one-by-one, parses them, and assigns the result to

--- a/parse.go
+++ b/parse.go
@@ -25,6 +25,17 @@ type spec struct {
 // ErrHelp indicates that -h or --help were provided
 var ErrHelp = errors.New("help requested by user")
 
+// ErrVersion indicates that --version were provided
+var ErrVersion = errors.New("version requested by user")
+
+// Version set by the application, shown with the --version flag
+var Version = ""
+
+// SetVersion sets the version available for --version flag
+func SetVersion(version string) {
+	Version = version
+}
+
 // MustParse processes command line arguments and exits upon failure
 func MustParse(dest ...interface{}) {
 	p, err := NewParser(dest...)
@@ -35,6 +46,10 @@ func MustParse(dest ...interface{}) {
 	err = p.Parse(os.Args[1:])
 	if err == ErrHelp {
 		p.WriteHelp(os.Stdout)
+		os.Exit(0)
+	}
+	if err == ErrVersion {
+		p.WriteVersion(os.Stdout)
 		os.Exit(0)
 	}
 	if err != nil {
@@ -147,6 +162,9 @@ func (p *Parser) Parse(args []string) error {
 	for _, arg := range args {
 		if arg == "-h" || arg == "--help" {
 			return ErrHelp
+		}
+		if Version != "" && arg == "--version" {
+			return ErrVersion
 		}
 		if arg == "--" {
 			break

--- a/usage.go
+++ b/usage.go
@@ -114,6 +114,11 @@ func printOption(w io.Writer, spec *spec) {
 	fmt.Fprint(w, "\n")
 }
 
+// WriteVersion outputs the version information
+func (p *Parser) WriteVersion(w io.Writer) {
+	fmt.Fprintf(w, "%s %s\n", filepath.Base(os.Args[0]), Version)
+}
+
 func synopsis(spec *spec, form string) string {
 	if spec.isBool {
 		return form

--- a/usage.go
+++ b/usage.go
@@ -116,7 +116,7 @@ func printOption(w io.Writer, spec *spec) {
 
 // WriteVersion outputs the version information
 func (p *Parser) WriteVersion(w io.Writer) {
-	fmt.Fprintf(w, "%s %s\n", filepath.Base(os.Args[0]), Version)
+	fmt.Fprintf(w, "%s %s\n", filepath.Base(os.Args[0]), p.Version)
 }
 
 func synopsis(spec *spec, form string) string {

--- a/usage.go
+++ b/usage.go
@@ -85,6 +85,9 @@ func (p *Parser) WriteHelp(w io.Writer) {
 
 	// write the list of built in options
 	printOption(w, &spec{isBool: true, long: "help", short: "h", help: "display this help and exit"})
+	if p.Version != "" {
+		printOption(w, &spec{isBool: true, long: "version", help: "output version information and exit"})
+	}
 }
 
 func printOption(w io.Writer, spec *spec) {

--- a/usage_test.go
+++ b/usage_test.go
@@ -52,6 +52,29 @@ options:
 	assert.Equal(t, expectedHelp, help.String())
 }
 
+func TestVersionInHelp(t *testing.T) {
+	expectedHelp := `usage: example [--verbose]
+
+options:
+  --verbose, -v          verbosity level
+  --help, -h             display this help and exit
+  --version              output version information and exit
+`
+	var args struct {
+		Verbose bool `arg:"-v,help:verbosity level"`
+	}
+
+	SetVersion("1.2.3")
+	p, err := NewParser(&args)
+	require.NoError(t, err)
+
+	os.Args[0] = "example"
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}
+
 func TestWriteVersion(t *testing.T) {
 	expectedVersion := "example 1.0.0\n"
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -51,3 +51,20 @@ options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+func TestWriteVersion(t *testing.T) {
+	expectedVersion := "example 1.0.0\n"
+
+	var args struct {
+	}
+
+	SetVersion("1.0.0")
+	p, err := NewParser(&args)
+	require.NoError(t, err)
+
+	os.Args[0] = "example"
+
+	var version bytes.Buffer
+	p.WriteVersion(&version)
+	assert.Equal(t, expectedVersion, version.String())
+}


### PR DESCRIPTION
I took a stab at issue #11 and this is the result.

I was unsure on how you wanted to delegate to `defaultParser` so I made two commits 7b2750d is my initial idea with a global function only, fe56683 uses the `defaultParser` and `SetVersion` on `Parser`. If you think it looks good I could squash them into one commit before pulling it in. Perhaps we should keep the commits as separate as they document the implementation flow, it's up to you.

To be able to use the `defaultParser` I split the spec parsing to a separate private function, this maintains the public API with NewParser.

Please tell me if you have any comments or if I should do something more before you could pull it in. 
