### PR TITLE
Add built ins to options in help output

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -54,6 +54,7 @@ type spec struct {
 	positional bool
 	help       string
 	wasPresent bool
+	isBool     bool
 }
 
 // ErrHelp indicates that -h or --help were provided
@@ -133,6 +134,11 @@ func NewParser(dests ...interface{}) (*Parser, error) {
 				reflect.Map, reflect.Ptr, reflect.Struct,
 				reflect.Complex64, reflect.Complex128:
 				return nil, fmt.Errorf("%s.%s: %s fields are not supported", t.Name(), field.Name, scalarType.Kind())
+			}
+
+			// Specify that it is a bool for usage
+			if scalarType.Kind() == reflect.Bool {
+				spec.isBool = true
 			}
 
 			// Look at the tag

--- a/usage.go
+++ b/usage.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 )
 
@@ -78,30 +77,35 @@ func (p *Parser) WriteHelp(w io.Writer) {
 	}
 
 	// write the list of options
-	if len(options) > 0 {
-		fmt.Fprint(w, "\noptions:\n")
-		const colWidth = 25
-		for _, spec := range options {
-			left := "  " + synopsis(spec, "--"+spec.long)
-			if spec.short != "" {
-				left += ", " + synopsis(spec, "-"+spec.short)
-			}
-			fmt.Fprint(w, left)
-			if spec.help != "" {
-				if len(left)+2 < colWidth {
-					fmt.Fprint(w, strings.Repeat(" ", colWidth-len(left)))
-				} else {
-					fmt.Fprint(w, "\n"+strings.Repeat(" ", colWidth))
-				}
-				fmt.Fprint(w, spec.help)
-			}
-			fmt.Fprint(w, "\n")
-		}
+	fmt.Fprint(w, "\noptions:\n")
+	for _, spec := range options {
+		printOption(w, spec)
 	}
+
+	// write the list of built in options
+	printOption(w, &spec{isBool: true, long: "help", short: "h", help: "display this help and exit"})
+}
+
+func printOption(w io.Writer, spec *spec) {
+	const colWidth = 25
+	left := "  " + synopsis(spec, "--"+spec.long)
+	if spec.short != "" {
+		left += ", " + synopsis(spec, "-"+spec.short)
+	}
+	fmt.Fprint(w, left)
+	if spec.help != "" {
+		if len(left)+2 < colWidth {
+			fmt.Fprint(w, strings.Repeat(" ", colWidth-len(left)))
+		} else {
+			fmt.Fprint(w, "\n"+strings.Repeat(" ", colWidth))
+		}
+		fmt.Fprint(w, spec.help)
+	}
+	fmt.Fprint(w, "\n")
 }
 
 func synopsis(spec *spec, form string) string {
-	if spec.dest.Kind() == reflect.Bool {
+	if spec.isBool {
 		return form
 	}
 	return form + " " + strings.ToUpper(spec.long)

--- a/usage_test.go
+++ b/usage_test.go
@@ -23,6 +23,7 @@ options:
   --dataset DATASET      dataset to use
   --optimize OPTIMIZE, -O OPTIMIZE
                          optimization level
+  --help, -h             display this help and exit
 `
 	var args struct {
 		Input    string   `arg:"positional"`


### PR DESCRIPTION
Adds help to the options in help output with an easy way to add more
built ins.

Help and version flags is usually shown in the help output. E.g. ls output

```
      --help     display this help and exit
      --version  output version information and exit
```