### PR TITLE
Fix bug with error not being written to stderr

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -12,7 +12,7 @@ import (
 // Fail prints usage information to stderr and exits with non-zero status
 func (p *Parser) Fail(msg string) {
 	p.WriteUsage(os.Stderr)
-	fmt.Println("error:", msg)
+	fmt.Fprintln(os.Stderr, "error:", msg)
 	os.Exit(-1)
 }
 


### PR DESCRIPTION
Only the usage message was written to stderr, the error was written with
the standard fmt.Println.

I noticed this bug with my first pull request.