### PR TITLE
Fix lint warning

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -103,7 +103,6 @@ func (p *Parser) WriteHelp(w io.Writer) {
 func synopsis(spec *spec, form string) string {
 	if spec.dest.Kind() == reflect.Bool {
 		return form
-	} else {
-		return form + " " + strings.ToUpper(spec.long)
 	}
+	return form + " " + strings.ToUpper(spec.long)
 }


### PR DESCRIPTION
I ran gometalinter on the project, and some warnings came up. This pull request fixes one of the (the easiest).

Output was

```
$ gometalinter .
usage.go:106:9:warning: if block ends with a return statement, so drop this else and outdent its block (golint)
parse.go:197::warning: cyclomatic complexity 30 of function process() is high (> 10) (gocyclo)
parse.go:94::warning: cyclomatic complexity 19 of function NewParser() is high (> 10) (gocyclo)
parse.go:345::warning: cyclomatic complexity 12 of function setScalar() is high (> 10) (gocyclo)
```

After patch

```
$ gometalinter .
parse.go:197::warning: cyclomatic complexity 30 of function process() is high (> 10) (gocyclo)
parse.go:94::warning: cyclomatic complexity 19 of function NewParser() is high (> 10) (gocyclo)
parse.go:345::warning: cyclomatic complexity 12 of function setScalar() is high (> 10) (gocyclo)
```