### PR TITLE
Add default tag to struct parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ args.Foo = "default value"
 arg.MustParse(&args)
 ```
 
+Or if you want the default value printed in usage
+
+```go
+var args struct {
+	Foo string `arg:"default:Foo Bar"`
+	Bar bool
+}
+arg.MustParse(&args)
+```
+
 ### Arguments with multiple values
 ```go
 var args struct {

--- a/parse.go
+++ b/parse.go
@@ -46,14 +46,15 @@ import (
 
 // spec represents a command line option
 type spec struct {
-	dest       reflect.Value
-	long       string
-	short      string
-	multiple   bool
-	required   bool
-	positional bool
-	help       string
-	wasPresent bool
+	dest         reflect.Value
+	long         string
+	short        string
+	multiple     bool
+	required     bool
+	positional   bool
+	help         string
+	wasPresent   bool
+	defaultValue string
 }
 
 // ErrHelp indicates that -h or --help were provided
@@ -158,6 +159,8 @@ func NewParser(dests ...interface{}) (*Parser, error) {
 						spec.positional = true
 					case key == "help":
 						spec.help = value
+					case key == "default":
+						spec.defaultValue = value
 					default:
 						return nil, fmt.Errorf("unrecognized tag '%s' on field %s", key, tag)
 					}
@@ -206,6 +209,16 @@ func process(specs []*spec, args []string) error {
 		}
 		if spec.short != "" {
 			optionMap[spec.short] = spec
+		}
+
+		// handle default value
+		if spec.defaultValue != "" {
+			if spec.multiple {
+				values := strings.Split(spec.defaultValue, " ")
+				setSlice(spec.dest, values)
+			} else {
+				setScalar(spec.dest, spec.defaultValue)
+			}
 		}
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -329,6 +329,21 @@ func TestUnknownTag(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDefaultTag(t *testing.T) {
+	var args struct {
+		Foo  int    `arg:"default:42"`
+		Bar  bool   `arg:"default:true"`
+		Baz  string `arg:"default:Foo Bar"`
+		List []int  `arg:"default:1 2 3 4"`
+	}
+	err := Parse(&args)
+	require.NoError(t, err)
+	assert.Equal(t, 42, args.Foo)
+	assert.Equal(t, true, args.Bar)
+	assert.Equal(t, "Foo Bar", args.Baz)
+	assert.Equal(t, []int{1, 2, 3, 4}, args.List)
+}
+
 func TestParse(t *testing.T) {
 	var args struct {
 		Foo string

--- a/usage.go
+++ b/usage.go
@@ -95,6 +95,10 @@ func (p *Parser) WriteHelp(w io.Writer) {
 				}
 				fmt.Fprint(w, spec.help)
 			}
+			if spec.defaultValue != "" {
+				fmt.Fprintf(w, strings.Repeat(" ", 8))
+				fmt.Fprintf(w, "Default=%s", spec.defaultValue)
+			}
 			fmt.Fprint(w, "\n")
 		}
 	}

--- a/usage_test.go
+++ b/usage_test.go
@@ -10,15 +10,16 @@ import (
 )
 
 func TestWriteUsage(t *testing.T) {
-	expectedUsage := "usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]\n"
+	expectedUsage := "usage: example [--name NAME] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]\n"
 
-	expectedHelp := `usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]
+	expectedHelp := `usage: example [--name NAME] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]
 
 positional arguments:
   input
   output
 
 options:
+  --name NAME            name to use        Default=Foo Bar
   --verbose, -v          verbosity level
   --dataset DATASET      dataset to use
   --optimize OPTIMIZE, -O OPTIMIZE
@@ -27,6 +28,7 @@ options:
 	var args struct {
 		Input    string   `arg:"positional"`
 		Output   []string `arg:"positional"`
+		Name     string   `arg:"help:name to use,default:Foo Bar"`
 		Verbose  bool     `arg:"-v,help:verbosity level"`
 		Dataset  string   `arg:"help:dataset to use"`
 		Optimize int      `arg:"-O,help:optimization level"`


### PR DESCRIPTION
This makes it possible to set a default value in the struct initializer,
instead of before the parsing. The improvement is that the default value
is outputted in the usage text. Removing the need to update the default
value in multiple places.

This pull request is not ready to merge. I would like to discuss the presentation of the default value. Right now the default value is printed eight spaced to the right of the help text column. I think this can be improved. Suggestions?

Also, this change will not merge cleanly with my other pull requests (I think) so after, and if, they are pulled I can rebase and fix conflicts.