### PR TITLE
add support for pointers and TextUnmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ hello true
 
 ```go
 var args struct {
-	Foo string `arg:"required"`
-	Bar bool
+	ID      int `arg:"required"`
+	Timeout time.Duration
 }
 arg.MustParse(&args)
 ```
 
 ```shell
 $ ./example
-usage: example --foo FOO [--bar] 
-error: --foo is required
+usage: example --id ID [--timeout TIMEOUT]
+error: --id is required
 ```
 
 ### Positional arguments
@@ -159,6 +159,53 @@ if args.Foo == "" && args.Bar == "" {
 ./example
 usage: samples [--foo FOO] [--bar BAR]
 error: you must provide one of --foo and --bar
+```
+
+### Custom parsing
+
+You can implement your own argument parser by implementing `encoding.TextUnmarshaler`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alexflint/go-arg"
+)
+
+// Accepts command line arguments of the form "head.tail"
+type NameDotName struct {
+	Head, Tail string
+}
+
+func (n *NameDotName) UnmarshalText(b []byte) error {
+	s := string(b)
+	pos := strings.Index(s, ".")
+	if pos == -1 {
+		return fmt.Errorf("missing period in %s", s)
+	}
+	n.Head = s[:pos]
+	n.Tail = s[pos+1:]
+	return nil
+}
+
+func main() {
+	var args struct {
+		Name *NameDotName
+	}
+	arg.MustParse(&args)
+	fmt.Printf("%#v\n", args.Name)
+}
+```
+```shell
+$ ./example --name=foo.bar
+&main.NameDotName{Head:"foo", Tail:"bar"}
+
+$ ./example --name=oops
+usage: example [--name NAME]
+error: error processing --name: missing period in "oops"
 ```
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## Structured argument parsing for Go
 
+```shell
+go get github.com/alexflint/go-arg
+```
+
 Declare the command line arguments your program accepts by defining a struct.
 
 ```go
@@ -206,12 +210,6 @@ $ ./example --name=foo.bar
 $ ./example --name=oops
 usage: example [--name NAME]
 error: error processing --name: missing period in "oops"
-```
-
-### Installation
-
-```shell
-go get github.com/alexflint/go-arg
 ```
 
 ### Documentation

--- a/scalar.go
+++ b/scalar.go
@@ -8,19 +8,33 @@ import (
 	"time"
 )
 
-var (
-	durationType        = reflect.TypeOf(time.Duration(0))
-	textUnmarshalerType = reflect.TypeOf([]encoding.TextUnmarshaler{}).Elem()
-)
-
 // set a value from a string
 func setScalar(v reflect.Value, s string) error {
 	if !v.CanSet() {
 		return fmt.Errorf("field is not exported")
 	}
 
-	// If we have a time.Duration then use time.ParseDuration
-	if v.Type() == durationType {
+	// If we have a nil pointer then allocate a new object
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		v.Set(reflect.New(v.Type().Elem()))
+	}
+
+	// Get the object as an interface
+	scalar := v.Interface()
+
+	// If it implements encoding.TextUnmarshaler then use that
+	if scalar, ok := scalar.(encoding.TextUnmarshaler); ok {
+		return scalar.UnmarshalText([]byte(s))
+	}
+
+	// If we have a pointer then dereference it
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// Switch on concrete type
+	switch scalar.(type) {
+	case time.Duration:
 		x, err := time.ParseDuration(s)
 		if err != nil {
 			return err
@@ -29,6 +43,7 @@ func setScalar(v reflect.Value, s string) error {
 		return nil
 	}
 
+	// Switch on kind so that we can handle derived types
 	switch v.Kind() {
 	case reflect.String:
 		v.SetString(s)
@@ -57,7 +72,7 @@ func setScalar(v reflect.Value, s string) error {
 		}
 		v.SetFloat(x)
 	default:
-		return fmt.Errorf("not a scalar type: %s", v.Kind())
+		return fmt.Errorf("cannot parse argument into %s", v.Type().String())
 	}
 	return nil
 }


### PR DESCRIPTION
This pr makes it possible to use the `encoding.TextUnmarshaler` interface to implement custom argument parsers.