### PR TITLE
Parse IP addresses, MAC addresses, and email addresses

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -2,6 +2,7 @@ package arg
 
 import (
 	"net"
+	"net/mail"
 	"os"
 	"strings"
 	"testing"
@@ -577,5 +578,39 @@ func TestInvalidIPAddress(t *testing.T) {
 		Host net.IP
 	}
 	err := parse("--host xxx", &args)
+	assert.Error(t, err)
+}
+
+func TestMAC(t *testing.T) {
+	var args struct {
+		Host net.HardwareAddr
+	}
+	err := parse("--host 0123.4567.89ab", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "01:23:45:67:89:ab", args.Host.String())
+}
+
+func TestInvalidMac(t *testing.T) {
+	var args struct {
+		Host net.HardwareAddr
+	}
+	err := parse("--host xxx", &args)
+	assert.Error(t, err)
+}
+
+func TestMailAddr(t *testing.T) {
+	var args struct {
+		Recipient mail.Address
+	}
+	err := parse("--recipient foo@example.com", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "<foo@example.com>", args.Recipient.String())
+}
+
+func TestInvalidMailAddr(t *testing.T) {
+	var args struct {
+		Recipient mail.Address
+	}
+	err := parse("--recipient xxx", &args)
 	assert.Error(t, err)
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,6 +1,7 @@
 package arg
 
 import (
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -540,4 +541,41 @@ func TestSliceUnmarhsaler(t *testing.T) {
 	require.Len(t, *args.Foo, 1)
 	assert.EqualValues(t, 5, (*args.Foo)[0])
 	assert.Equal(t, "xyz", args.Bar)
+}
+
+func TestIP(t *testing.T) {
+	var args struct {
+		Host net.IP
+	}
+	err := parse("--host 192.168.0.1", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.0.1", args.Host.String())
+}
+
+func TestPtrToIP(t *testing.T) {
+	var args struct {
+		Host *net.IP
+	}
+	err := parse("--host 192.168.0.1", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.0.1", args.Host.String())
+}
+
+func TestIPSlice(t *testing.T) {
+	var args struct {
+		Host []net.IP
+	}
+	err := parse("--host 192.168.0.1 127.0.0.1", &args)
+	require.NoError(t, err)
+	require.Len(t, args.Host, 2)
+	assert.Equal(t, "192.168.0.1", args.Host[0].String())
+	assert.Equal(t, "127.0.0.1", args.Host[1].String())
+}
+
+func TestInvalidIPAddress(t *testing.T) {
+	var args struct {
+		Host net.IP
+	}
+	err := parse("--host xxx", &args)
+	assert.Error(t, err)
 }

--- a/scalar.go
+++ b/scalar.go
@@ -3,10 +3,56 @@ package arg
 import (
 	"encoding"
 	"fmt"
+	"net"
+	"net/mail"
 	"reflect"
 	"strconv"
 	"time"
 )
+
+// The reflected form of some special types
+var (
+	textUnmarshalerType = reflect.TypeOf([]encoding.TextUnmarshaler{}).Elem()
+	durationType        = reflect.TypeOf(time.Duration(0))
+	mailAddressType     = reflect.TypeOf(mail.Address{})
+	ipType              = reflect.TypeOf(net.IP{})
+	macType             = reflect.TypeOf(net.HardwareAddr{})
+)
+
+// isScalar returns true if the type can be parsed from a single string
+func isScalar(t reflect.Type) (scalar, boolean bool) {
+	// If it implements encoding.TextUnmarshaler then use that
+	if t.Implements(textUnmarshalerType) {
+		// scalar=YES, boolean=NO
+		return true, false
+	}
+
+	// If we have a pointer then dereference it
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	// Check for other special types
+	switch t {
+	case durationType, mailAddressType, ipType, macType:
+		// scalar=YES, boolean=NO
+		return true, false
+	}
+
+	// Fall back to checking the kind
+	switch t.Kind() {
+	case reflect.Bool:
+		// scalar=YES, boolean=YES
+		return true, true
+	case reflect.String, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		// scalar=YES, boolean=NO
+		return true, false
+	}
+	// scalar=NO, boolean=NO
+	return false, false
+}
 
 // set a value from a string
 func setScalar(v reflect.Value, s string) error {
@@ -35,12 +81,30 @@ func setScalar(v reflect.Value, s string) error {
 	// Switch on concrete type
 	switch scalar.(type) {
 	case time.Duration:
-		x, err := time.ParseDuration(s)
+		duration, err := time.ParseDuration(s)
 		if err != nil {
 			return err
 		}
-		v.Set(reflect.ValueOf(x))
+		v.Set(reflect.ValueOf(duration))
 		return nil
+	case mail.Address:
+		addr, err := mail.ParseAddress(s)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(*addr))
+	case net.IP:
+		ip := net.ParseIP(s)
+		if ip == nil {
+			return fmt.Errorf(`invalid IP address: "%s"`, s)
+		}
+		v.Set(reflect.ValueOf(ip))
+	case net.HardwareAddr:
+		ip, err := net.ParseMAC(s)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(ip))
 	}
 
 	// Switch on kind so that we can handle derived types

--- a/scalar.go
+++ b/scalar.go
@@ -93,18 +93,21 @@ func setScalar(v reflect.Value, s string) error {
 			return err
 		}
 		v.Set(reflect.ValueOf(*addr))
+		return nil
 	case net.IP:
 		ip := net.ParseIP(s)
 		if ip == nil {
 			return fmt.Errorf(`invalid IP address: "%s"`, s)
 		}
 		v.Set(reflect.ValueOf(ip))
+		return nil
 	case net.HardwareAddr:
 		ip, err := net.ParseMAC(s)
 		if err != nil {
 			return err
 		}
 		v.Set(reflect.ValueOf(ip))
+		return nil
 	}
 
 	// Switch on kind so that we can handle derived types

--- a/usage.go
+++ b/usage.go
@@ -97,7 +97,7 @@ func (p *Parser) WriteHelp(w io.Writer) {
 	}
 
 	// write the list of built in options
-	printOption(w, &spec{isBool: true, long: "help", short: "h", help: "display this help and exit"})
+	printOption(w, &spec{boolean: true, long: "help", short: "h", help: "display this help and exit"})
 }
 
 func printOption(w io.Writer, spec *spec) {
@@ -127,7 +127,7 @@ func printOption(w io.Writer, spec *spec) {
 }
 
 func synopsis(spec *spec, form string) string {
-	if spec.isBool {
+	if spec.boolean {
 		return form
 	}
 	return form + " " + strings.ToUpper(spec.long)


### PR DESCRIPTION
This pr adds support for `net.IP`, `net.HardwareAddr`, and `mail.Message`. Parsing is performed using the relevant standard library functions.