### PR TITLE
Defaults for multiples, intended behaviour

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -322,6 +322,11 @@ func setSlice(dest reflect.Value, values []string) error {
 		elem = elem.Elem()
 	}
 
+	// Truncate the dest slice in case default values exist
+	if !dest.IsNil() {
+		dest.SetLen(0)
+	}
+
 	for _, s := range values {
 		v := reflect.New(elem)
 		if err := setScalar(v.Elem(), s); err != nil {

--- a/parse_test.go
+++ b/parse_test.go
@@ -250,6 +250,19 @@ func TestMultipleWithEq(t *testing.T) {
 	assert.Equal(t, []string{"x"}, args.Bar)
 }
 
+func TestMultipleWithDefault(t *testing.T) {
+	var args struct {
+		Foo []int
+		Bar []string
+	}
+	args.Foo = []int{42}
+	args.Bar = []string{"foo"}
+	err := parse("--foo 1 2 3 --bar x y z", &args)
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2, 3}, args.Foo)
+	assert.Equal(t, []string{"x", "y", "z"}, args.Bar)
+}
+
 func TestExemptField(t *testing.T) {
 	var args struct {
 		Foo string


### PR DESCRIPTION
This is a failing test case, not to be merged.
I would like to hear from you what the intended behaviour is in this case.

Right now, when you set default values for a arg with multiple, the default values is not overridden, but the provided values are appended to the default values. But for non multiple the default value is overridden.

Is this intended behaviour? If that is the case, should we add some documentation about this in the README?

This caused me some head scratching before I figured out the cause, as I assumed the default values would be overridden. My workaround for this is at https://github.com/walle/lll/blob/971fc17f2a8231d15830f08835476e3170be495f/cmd/lll/main.go#L27-L50

If this is not the intended behaviour I could take a stab at fixing it in this pull request. 