### PR TITLE
Add support for version strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,28 @@ usage: samples [--foo FOO] [--bar BAR]
 error: you must provide one of --foo and --bar
 ```
 
+### Version strings
+
+```go
+type args struct {
+	...
+}
+
+func (args) Version() string {
+	return "someprogram 4.3.0"
+}
+
+func main() {
+	var args args
+	arg.MustParse(&args)
+}
+```
+
+```shell
+$ ./example --version
+someprogram 4.3.0
+```
+
 ### Custom parsing
 
 You can implement your own argument parser by implementing `encoding.TextUnmarshaler`:

--- a/usage.go
+++ b/usage.go
@@ -29,6 +29,10 @@ func (p *Parser) WriteUsage(w io.Writer) {
 		}
 	}
 
+	if p.version != "" {
+		fmt.Fprintln(w, p.version)
+	}
+
 	fmt.Fprintf(w, "usage: %s", p.config.Program)
 
 	// write the option component of the usage message
@@ -97,6 +101,9 @@ func (p *Parser) WriteHelp(w io.Writer) {
 
 	// write the list of built in options
 	printOption(w, &spec{boolean: true, long: "help", short: "h", help: "display this help and exit"})
+	if p.version != "" {
+		printOption(w, &spec{boolean: true, long: "version", help: "display version and exit"})
+	}
 }
 
 func printOption(w io.Writer, spec *spec) {

--- a/usage_test.go
+++ b/usage_test.go
@@ -100,3 +100,32 @@ options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+type versioned struct{}
+
+// Version returns the version for this program
+func (versioned) Version() string {
+	return "example 3.2.1"
+}
+
+func TestUsageWithVersion(t *testing.T) {
+	expectedHelp := `example 3.2.1
+usage: example
+
+options:
+  --help, -h             display this help and exit
+  --version              display version and exit
+`
+	os.Args[0] = "example"
+	p, err := NewParser(Config{}, &versioned{})
+	require.NoError(t, err)
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	actual := help.String()
+	t.Logf("Expected:\n%s", expectedHelp)
+	t.Logf("Actual:\n%s", actual)
+	if expectedHelp != actual {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This makes it possible to specify version strings as suggested by @brentp in #37 :


```go
type args struct {
	...
}

func (args) Version() string {
	return "someprogram 4.3.0"
}

func main() {
	var args args
	arg.MustParse(&args)
}
```

```shell
$ ./example --version
someprogram 4.3.0
```

```shell
$ ./example --help
someprogram 4.3.0
usage: version

options:
  --help, -h             display this help and exit
  --version              display version and exit
```