### PR TITLE
add support for embedded structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,34 @@ $ ./example --version
 someprogram 4.3.0
 ```
 
+### Embedded structs
+
+The fields of embedded structs are treated just like regular fields:
+
+```go
+
+type DatabaseOptions struct {
+	Host     string
+	Username string
+	Password string
+}
+
+type LogOptions struct {
+	LogFile string
+	Verbose bool
+}
+
+func main() {
+	var args struct {
+		DatabaseOptions
+		LogOptions
+	}
+	arg.MustParse(&args)
+}
+```
+
+As usual, any field tagged with `arg:"-"` is ignored.
+
 ### Custom parsing
 
 You can implement your own argument parser by implementing `encoding.TextUnmarshaler`:

--- a/parse_test.go
+++ b/parse_test.go
@@ -633,3 +633,24 @@ func TestInvalidMailAddr(t *testing.T) {
 	err := parse("--recipient xxx", &args)
 	assert.Error(t, err)
 }
+
+type A struct {
+	X string
+}
+
+type B struct {
+	Y int
+}
+
+func TestEmbedded(t *testing.T) {
+	var args struct {
+		A
+		B
+		Z bool
+	}
+	err := parse("--x=hello --y=321 --z", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", args.X)
+	assert.Equal(t, 321, args.Y)
+	assert.Equal(t, true, args.Z)
+}


### PR DESCRIPTION
This pr adds support for embedded structs. Embedded struct fields are treated the same as first-order fields, unless the embedding field is amarked with `arg:"-"`, in which case that embedded struct is ignored.