### PR TITLE
print description below usage in help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ func main() {
 
 ```shell
 $ ./example -h
-this program does this and that
 usage: example [--foo FOO]
+this program does this and that
 
 options:
   --foo FOO

--- a/parse.go
+++ b/parse.go
@@ -82,10 +82,10 @@ type Versioned interface {
 }
 
 // Described is the interface that the destination struct should implement to
-// make a description string appear at the top of the help message.
+// make a description string appear below the usage message.
 type Described interface {
 	// Description returns the string that will be printed on a line by itself
-	// at the top of the help message.
+	// below the usage message.
 	Description() string
 }
 

--- a/usage.go
+++ b/usage.go
@@ -29,9 +29,6 @@ func (p *Parser) WriteUsage(w io.Writer) {
 		}
 	}
 
-	if p.description != "" {
-		fmt.Fprintln(w, p.description)
-	}
 	if p.version != "" {
 		fmt.Fprintln(w, p.version)
 	}
@@ -77,6 +74,9 @@ func (p *Parser) WriteHelp(w io.Writer) {
 	}
 
 	p.WriteUsage(w)
+	if p.description != "" {
+		fmt.Fprintln(w, p.description)
+	}
 
 	// write the list of positionals
 	if len(positionals) > 0 {

--- a/usage_test.go
+++ b/usage_test.go
@@ -138,8 +138,8 @@ func (described) Description() string {
 }
 
 func TestUsageWithDescription(t *testing.T) {
-	expectedHelp := `this program does this and that
-usage: example
+	expectedHelp := `usage: example
+this program does this and that
 
 options:
   --help, -h             display this help and exit


### PR DESCRIPTION
This is probably more inline with the UNIX style. Prints description below usage and only if the help flag is present e.g.

```bash
$ grep
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
```

```bash
$ grep --help
Usage: grep [OPTION]... PATTERN [FILE]...
Search for PATTERN in each FILE or standard input.
PATTERN is, by default, a basic regular expression (BRE).
Example: grep -i 'hello world' menu.h main.c
...
```
