### PR TITLE
fix crash where os.Args does not contains arguments

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -36,6 +36,9 @@ func MustParse(dest ...interface{}) *Parser {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
+	if len(os.Args) <= 1 {
+		return p
+	}
 	err = p.Parse(os.Args[1:])
 	if err == ErrHelp {
 		p.WriteHelp(os.Stdout)
@@ -56,6 +59,9 @@ func Parse(dest ...interface{}) error {
 	p, err := NewParser(Config{}, dest...)
 	if err != nil {
 		return err
+	}
+	if len(os.Args) <= 1 {
+		return nil
 	}
 	return p.Parse(os.Args[1:])
 }


### PR DESCRIPTION
When run app *(with go-arg)* from the console is always passed at least an empty one argument, **but** if run app from another application, and do not set arguments, length `os.Args` can be only **1**, and your `os.Args[1:]` will lead to `panic: runtime error: slice bounds out of range`...
What you think about it?