### PR TITLE
Do not crash when os.Args is empty

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -36,7 +36,7 @@ func MustParse(dest ...interface{}) *Parser {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
-	err = p.Parse(os.Args[1:])
+	err = p.Parse(flags())
 	if err == ErrHelp {
 		p.WriteHelp(os.Stdout)
 		os.Exit(0)
@@ -57,7 +57,15 @@ func Parse(dest ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	return p.Parse(os.Args[1:])
+	return p.Parse(flags())
+}
+
+// flags gets all command line arguments other than the first (program name)
+func flags() []string {
+	if len(os.Args) == 0 { // os.Args could be empty
+		return nil
+	}
+	return os.Args[1:]
 }
 
 // Config represents configuration options for an argument parser

--- a/parse_test.go
+++ b/parse_test.go
@@ -654,3 +654,17 @@ func TestEmbedded(t *testing.T) {
 	assert.Equal(t, 321, args.Y)
 	assert.Equal(t, true, args.Z)
 }
+
+func TestEmptyArgs(t *testing.T) {
+	origArgs := os.Args
+
+	// test what happens if somehow os.Args is empty
+	os.Args = nil
+	var args struct {
+		Foo string
+	}
+	MustParse(&args)
+
+	// put the original arguments back
+	os.Args = origArgs
+}


### PR DESCRIPTION
Fixes a panic caused by `os.Args` being empty. This is not a situation I expect to come up often, but still we should not panic in this case.