### PR TITLE
fix parsing of single "-" as value; e.g. --foo -

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -320,7 +320,7 @@ func process(specs []*spec, args []string) error {
 
 		// if we have something like "--foo" then the value is the next argument
 		if value == "" {
-			if i+1 == len(args) || strings.HasPrefix(args[i+1], "-") {
+			if i+1 == len(args) || (strings.HasPrefix(args[i+1], "-") && len(args[i+1]) > 1) {
 				return fmt.Errorf("missing value for %s", arg)
 			}
 			value = args[i+1]

--- a/parse_test.go
+++ b/parse_test.go
@@ -39,6 +39,15 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "bar", args.Foo)
 }
 
+func TestDashAsValue(t *testing.T) {
+	var args struct {
+		Foo string
+	}
+	err := parse("--foo -", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "-", args.Foo)
+}
+
 func TestInt(t *testing.T) {
 	var args struct {
 		Foo int


### PR DESCRIPTION
Having a flag like this `--foo -` results in an error "missing value for foo".
However, consistent with the `flag` package, this should be acceptable and the value of foo should be "-".

This PR fixes it for the single value flag but I think this should also be fixed for multi-value flags e.g. `--foo x y - z`.