### PR TITLE
deal with "-" as option value

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -693,3 +693,49 @@ func TestEmptyArgs(t *testing.T) {
 	// put the original arguments back
 	os.Args = origArgs
 }
+
+func TestTooManyHyphens(t *testing.T) {
+	var args struct {
+		TooManyHyphens string `arg:"---x"`
+	}
+	err := parse("--foo -", &args)
+	assert.Error(t, err)
+}
+
+func TestHyphenAsOption(t *testing.T) {
+	var args struct {
+		Foo string
+	}
+	err := parse("--foo -", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "-", args.Foo)
+}
+
+func TestHyphenAsPositional(t *testing.T) {
+	var args struct {
+		Foo string `arg:"positional"`
+	}
+	err := parse("-", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "-", args.Foo)
+}
+
+func TestHyphenInMultiOption(t *testing.T) {
+	var args struct {
+		Foo []string
+		Bar int
+	}
+	err := parse("--foo --- x - y --bar 3", &args)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"---", "x", "-", "y"}, args.Foo)
+	assert.Equal(t, 3, args.Bar)
+}
+
+func TestHyphenInMultiPositional(t *testing.T) {
+	var args struct {
+		Foo []string `arg:"positional"`
+	}
+	err := parse("--- x - y", &args)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"---", "x", "-", "y"}, args.Foo)
+}


### PR DESCRIPTION
This pr makes it possible to pass "-" as the value for an option or positional argument, as suggested by @mnsmar in #47. This fixes cases such as:

```
./myprog --version -
./myprog --users foo bar - baz
./myprog a - b
```