### PR TITLE
Allow spaces after each comma in tags

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -168,6 +168,7 @@ func NewParser(config Config, dests ...interface{}) (*Parser, error) {
 			// Look at the tag
 			if tag != "" {
 				for _, key := range strings.Split(tag, ",") {
+					key = strings.TrimLeft(key, " ")
 					var value string
 					if pos := strings.Index(key, ":"); pos != -1 {
 						value = key[pos+1:]

--- a/parse_test.go
+++ b/parse_test.go
@@ -131,7 +131,7 @@ func TestMixed(t *testing.T) {
 	var args struct {
 		Foo  string `arg:"-f"`
 		Bar  int
-		Baz  uint `arg:"positional"`
+		Baz  uint   `arg:"positional"`
 		Ham  bool
 		Spam float32
 	}
@@ -341,9 +341,9 @@ func TestMissingRequired(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestMissingRequiredMultiplePositional(t *testing.T) {
+func TestNonsenseKey(t *testing.T) {
 	var args struct {
-		X []string `arg:"positional, required"`
+		X []string `arg:"positional, nonsense"`
 	}
 	err := parse("x", &args)
 	assert.Error(t, err)
@@ -820,4 +820,14 @@ func TestSeparatePositionalInterweaved(t *testing.T) {
 	assert.Equal(t, []string{"bar1", "bar2", "bar3"}, args.Bar)
 	assert.Equal(t, "zzz", args.Pre)
 	assert.Equal(t, []string{"post1", "post2", "post3"}, args.Post)
+}
+
+func TestSpacesAllowedInTags(t *testing.T) {
+	var args struct {
+		Foo []string `arg:"--foo, -f, separate, required, help:quite nice really"`
+	}
+
+	err := parse("--foo one -f=two --foo=three -f four", &args)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one", "two", "three", "four"}, args.Foo)
 }


### PR DESCRIPTION
as per issue #56 (https://github.com/alexflint/go-arg/issues/56)