### PR TITLE
Fix providing multiple values via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,22 @@ $ NUM_WORKERS=4 ./example
 Workers: 4
 ```
 
+You should use a JSON array of strings (value will be converted if
+necessary) in the case of multiple values:
+
+```go
+var args struct {
+    Workers []int `arg:"env"`
+}
+arg.MustParse(&args)
+fmt.Println("Workers:", args.Workers)
+```
+
+```
+$ WORKERS='["1", "99"]' ./example
+Workers: [1 99]
+```
+
 ### Usage strings
 ```go
 var args struct {

--- a/parse_test.go
+++ b/parse_test.go
@@ -580,6 +580,42 @@ func TestEnvironmentVariableRequired(t *testing.T) {
 	assert.Equal(t, "bar", args.Foo)
 }
 
+func TestEnvironmentVariableSliceArgumentString(t *testing.T)  {
+	var args struct {
+		Foo []string `arg:"env"`
+	}
+	setenv(t, "FOO", "[\"bar\", \"baz\"]")
+	MustParse(&args)
+	assert.Equal(t, []string{"bar", "baz"}, args.Foo)
+}
+
+func TestEnvironmentVariableSliceArgumentInteger(t *testing.T)  {
+	var args struct {
+		Foo []int `arg:"env"`
+	}
+	setenv(t, "FOO", "[\"1\", \"99\"]")
+	MustParse(&args)
+	assert.Equal(t, []int{1, 99}, args.Foo)
+}
+
+func TestEnvironmentVariableSliceArgumentFloat(t *testing.T)  {
+	var args struct {
+		Foo []float32 `arg:"env"`
+	}
+	setenv(t, "FOO", "[\"1.1\", \"99.9\"]")
+	MustParse(&args)
+	assert.Equal(t, []float32{1.1, 99.9}, args.Foo)
+}
+
+func TestEnvironmentVariableSliceArgumentBool(t *testing.T)  {
+	var args struct {
+		Foo []bool `arg:"env"`
+	}
+	setenv(t, "FOO", "[\"true\", \"false\", \"0\", \"1\"]")
+	MustParse(&args)
+	assert.Equal(t, []bool{true, false, false, true}, args.Foo)
+}
+
 type textUnmarshaler struct {
 	val int
 }


### PR DESCRIPTION
Providing values to a slice of strings (or any other type of slices) resulted in an error like this one: `error: error processing environment variable EXAMPLE: cannot parse into []string`.