### PR TITLE
Tests for installation under go 1.10 and go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ before_install:
   - if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
+  - bash test/compile_with_go110.sh
+  - bash test/compile_with_go111.sh
+  - bash test/compile_with_go111_inside_gopath.sh

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,1 @@
+This directory contains integration tests that check that go-arg can be installed and compiled under both tgo 1.10 and go 1.11 (corresponding to the transition to the new go module system)

--- a/test/compile_with_go110.sh
+++ b/test/compile_with_go110.sh
@@ -4,9 +4,11 @@
 # under go 1.10, which was the last release before introduction of the new go
 # module system.
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 docker run \
     --rm \
-    -v $(pwd)/some-program:/src \
+    -v $DIR/some-program:/src \
     -w /src \
     golang:1.10 \
     bash -c "go get github.com/alexflint/go-arg && go build -o /dev/null"

--- a/test/compile_with_go110.sh
+++ b/test/compile_with_go110.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This test checks that we can correctly "go get" and then use the go-arg package
+# under go 1.10, which was the last release before introduction of the new go
+# module system.
+
+docker run \
+    --rm \
+    -v $(pwd)/some-program:/src \
+    -w /src \
+    golang:1.10 \
+    bash -c "go get github.com/alexflint/go-arg && go build -o /dev/null"

--- a/test/compile_with_go111.sh
+++ b/test/compile_with_go111.sh
@@ -3,9 +3,11 @@
 # This test checks that we can compile some code that depends on go-arg when using go 1.11 
 # with the new go module system active.
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 docker run \
     --rm \
-    -v $(pwd)/some-program:/src \
+    -v $DIR/some-program:/src \
     -w /src \
     golang:1.11 \
     go build -o /dev/null

--- a/test/compile_with_go111.sh
+++ b/test/compile_with_go111.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker run \
+    --rm \
+    -v $(pwd)/some-program:/src \
+    -w /src \
+    golang:1.11 \
+    go build

--- a/test/compile_with_go111.sh
+++ b/test/compile_with_go111.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This test checks that we can compile some code that depends on go-arg when using go 1.11 
+# with the new go module system active.
+
 docker run \
     --rm \
     -v $(pwd)/some-program:/src \

--- a/test/compile_with_go111.sh
+++ b/test/compile_with_go111.sh
@@ -5,4 +5,4 @@ docker run \
     -v $(pwd)/some-program:/src \
     -w /src \
     golang:1.11 \
-    go build
+    go build -o /dev/null

--- a/test/compile_with_go111_inside_gopath.sh
+++ b/test/compile_with_go111_inside_gopath.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Under go 1.11, modules are disabled by default when user code is located within the GOPATH.
+# In this test, we check that we can correctly "go get" the go-arg package, and then compile
+# some code that uses it.
+
+docker run \
+    --rm \
+    -v $(pwd)/some-program:/go/src/some-program \
+    -w /go/src/some-program \
+    golang:1.11 \
+    bash -c "go get github.com/alexflint/go-arg && go build"

--- a/test/compile_with_go111_inside_gopath.sh
+++ b/test/compile_with_go111_inside_gopath.sh
@@ -3,9 +3,11 @@
 # This test checks that we can correctly "go get" and then use the go-arg package using
 # go 1.11 when the code is within the GOPATH (in which case modules are disabled by default).
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 docker run \
     --rm \
-    -v $(pwd)/some-program:/go/src/some-program \
+    -v $DIR/some-program:/go/src/some-program \
     -w /go/src/some-program \
     golang:1.11 \
     bash -c "go get github.com/alexflint/go-arg && go build -o /dev/null"

--- a/test/compile_with_go111_inside_gopath.sh
+++ b/test/compile_with_go111_inside_gopath.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-# Under go 1.11, modules are disabled by default when user code is located within the GOPATH.
-# In this test, we check that we can correctly "go get" the go-arg package, and then compile
-# some code that uses it.
+# This test checks that we can correctly "go get" and then use the go-arg package using
+# go 1.11 when the code is within the GOPATH (in which case modules are disabled by default).
 
 docker run \
     --rm \
     -v $(pwd)/some-program:/go/src/some-program \
     -w /go/src/some-program \
     golang:1.11 \
-    bash -c "go get github.com/alexflint/go-arg && go build"
+    bash -c "go get github.com/alexflint/go-arg && go build -o /dev/null"

--- a/test/some-program/go.mod
+++ b/test/some-program/go.mod
@@ -1,0 +1,3 @@
+module some-program
+
+require github.com/alexflint/go-arg v1.0.0

--- a/test/some-program/go.sum
+++ b/test/some-program/go.sum
@@ -1,0 +1,10 @@
+github.com/alexflint/go-arg v1.0.0 h1:VWNnY3DyBHiq5lcwY2FlCE5t5qyHNV0o5i1bkCIHprU=
+github.com/alexflint/go-arg v1.0.0/go.mod h1:Cto8k5VtkP4pp0EXiWD4ZJMFOOinZ38ggVcQ/6CGuRI=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
+github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/test/some-program/main.go
+++ b/test/some-program/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/alexflint/go-arg"
+
+func main() {
+	var args struct {
+		Test string
+	}
+	arg.MustParse(&args)
+}


### PR DESCRIPTION
This PR adds tests that check that go-arg can be installed and compile under go 1.10 and go 1.11, both with and without the new Go module system active.