### PR TITLE
Allow subcommands to implement TextUnmarshaler

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -460,6 +460,15 @@ func (p *Parser) process(args []string) error {
 			v := p.val(subcmd.dest)
 			v.Set(reflect.New(v.Type().Elem())) // we already checked that all subcommands are struct pointers
 
+			// update current and last command to have help for the correct command on failure
+			curCmd = subcmd
+			p.lastCmd = curCmd
+
+			// check if subcommand struct implements TextUnmarshaler interface
+			if scalar.CanParse(reflect.TypeOf(v.Interface())) {
+				return scalar.ParseValue(v, strings.Join(args[i:], " "))
+			}
+
 			// add the new options to the set of allowed options
 			specs = append(specs, subcmd.specs...)
 
@@ -468,9 +477,6 @@ func (p *Parser) process(args []string) error {
 			if err != nil {
 				return err
 			}
-
-			curCmd = subcmd
-			p.lastCmd = curCmd
 			continue
 		}
 


### PR DESCRIPTION
In some corner cases you want to have custom parsingfor the whole
subcommand instead of just a single arg/flag. This change allows a
subcommand to define it's own implementation using the
encoding.TextUnmarshaler interface.

The limitation of this approach is that once it finds the subcommand
that has a custom implementation, it passes the rest of the args to it
and in the case that a parent command has flags, they need to come
before the subcommand.

For example:
  * parent --verbose child --what --ever arg1 arg2 (works as expected)
  * parent child --what --ever arg1 arg2 --verbose (the verbose flag
    will be passed to the custom implementation of child)