### PR TITLE
Subcommand Parser

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -35,6 +35,18 @@ func pparse(cmdline string, dest interface{}) (*Parser, error) {
 	return p, p.Parse(parts)
 }
 
+func pparsename(name string, cmdline string, dest interface{}) (*Parser, error) {
+	p, err := NewParser(Config{Program: name}, dest)
+	if err != nil {
+		return nil, err
+	}
+	var parts []string
+	if len(cmdline) > 0 {
+		parts = strings.Split(cmdline, " ")
+	}
+	return p, p.Parse(parts)
+}
+
 func TestString(t *testing.T) {
 	var args struct {
 		Foo string

--- a/subcommand.go
+++ b/subcommand.go
@@ -1,5 +1,29 @@
 package arg
 
+import (
+	"reflect"
+)
+
+// type to check for interface implementations
+var subcommandParserType = reflect.TypeOf((*SubcommandParser)(nil)).Elem()
+
+// SubcommandParser interface defines a way for subcommands to override the
+// default parsing of the subcommand struct. The implementor is given the
+// calling parser primed with the state so far and with calls to p.AddDestinations
+// can extent the list of args prior to calling p.Parse(args)
+type SubcommandParser interface {
+	SubcommandParse(p *Parser, args []string) error
+}
+
+func callSubcommandParser(v reflect.Value, p *Parser, args []string) error {
+	in := []reflect.Value{reflect.ValueOf(p), reflect.ValueOf(args)}
+	out := v.MethodByName("SubcommandParse").Call(in)
+	if out[0].IsNil() {
+		return nil
+	}
+	return out[0].Interface().(error)
+}
+
 // Subcommand returns the user struct for the subcommand selected by
 // the command line arguments most recently processed by the parser.
 // The return value is always a pointer to a struct. If no subcommand

--- a/usage.go
+++ b/usage.go
@@ -113,7 +113,7 @@ func printTwoCols(w io.Writer, left, help string, defaultVal *string) {
 
 // WriteHelp writes the usage string followed by the full help string for each option
 func (p *Parser) WriteHelp(w io.Writer) {
-	p.writeHelpForCommand(w, p.cmd)
+	p.writeHelpForCommand(w, p.curCmd)
 }
 
 // writeHelp writes the usage string for the given subcommand


### PR DESCRIPTION
This is a proper and more idiomatic way to implement what was suggested here https://github.com/alexflint/go-arg/pull/85

The main idea is that you have a struct as subcommand that has fields you cannot have TextUnmarshaler implemented on them (interfaces) or the flags of the command depend on some already provided flags.

This change gives the user the ability to override default behavior by implementing SubcommandParser interface. With the newly introduce parser.AddDestinations new specs can be added to the parser.

```go
type subCmdA struct {
	Type string
	// it can be any interface
	Options interface{} `arg:"-"`
}

func (cmd *subCmdA) SubcommandParse(p *Parser, args []string) error {
	opts := getWhateverConcreteOpts(args)

	p.AddDestinations(opts)

	err := p.Parse(args)

	// Now both cmd & opts have values
	cmd.Options = opts

	// this can also be arg.ErrHelp
	return err
}
```

You can expect the functionality to work as expected with flags meant for other specs.

I am open to the naming of the interface.