### PR TITLE
Add WriteSubcommandUsage and WriteSubcommandHelp

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -32,6 +32,10 @@ func (p *Parser) WriteUsage(w io.Writer) {
 	p.writeUsageForCommand(w, p.cmd)
 }
 
+func (p * Parser) WriteSubcommandUsage(w io.Writer) {
+	p.writeUsageForCommand(w, p.lastCmd)
+}
+
 // writeUsageForCommand writes usage information for the given subcommand
 func (p *Parser) writeUsageForCommand(w io.Writer, cmd *command) {
 	var positionals, options []*spec
@@ -114,6 +118,10 @@ func printTwoCols(w io.Writer, left, help string, defaultVal *string) {
 // WriteHelp writes the usage string followed by the full help string for each option
 func (p *Parser) WriteHelp(w io.Writer) {
 	p.writeHelpForCommand(w, p.cmd)
+}
+
+func (p *Parser) WriteSubcommandHelp(w io.Writer) {
+	p.writeHelpForCommand(w, p.lastCmd)
 }
 
 // writeHelp writes the usage string for the given subcommand


### PR DESCRIPTION
This PR adds two functions for emitting a help or usage message for subcommand.

The usage I have in my mind is something like the following:

```go
type args struct {
        // Defines subcommands
}

func main() {
        var args args
        argParser, err := arg.NewParser(arg.Config{}, &args)
        err = argParser.Parse(os.Args[1:])
        if err == arg.ErrHelp {
                // Note: argParser.WriteHelp() will emit the help command for the root command.
                argParser.WriteSubcommandHelp(os.Stdout)
        }
}
```

...Or is it possible to replace `p.cmd` with `p.lastCmd` in the following line? That way we need not add new methods.

https://github.com/alexflint/go-arg/blob/8baf7040d76473dd1d78c17b490d9d8cf6b1c584/usage.go#L116