### PR TITLE
Allow default values in struct tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: go
 go:
-  - "1.10"
   - "1.12"
-  - tip
-env:
-  - GO111MODULE=on  # will only be used in go 1.11
+  - "1.13"
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -142,10 +142,9 @@ Options:
 
 ```go
 var args struct {
-	Foo string
+	Foo string `default:"abc"`
 	Bar bool
 }
-args.Foo = "default value"
 arg.MustParse(&args)
 ```
 
@@ -307,9 +306,8 @@ func (n *NameDotName) MarshalText() ([]byte, error) {
 
 func main() {
 	var args struct {
-		Name NameDotName
+		Name NameDotName `default:"file.txt"`
 	}
-	args.Name = NameDotName{"file", "txt"}  // set default value
 	arg.MustParse(&args)
 	fmt.Printf("%#v\n", args.Name)
 }

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ var args struct {
 arg.MustParse(&args)
 ```
 
+### Default values (before v1.2)
+
+```go
+var args struct {
+	Foo string
+	Bar bool
+}
+arg.Foo = "abc"
+arg.MustParse(&args)
+```
+
 ### Arguments with multiple values
 ```go
 var args struct {

--- a/example_test.go
+++ b/example_test.go
@@ -30,12 +30,11 @@ func Example_defaultValues() {
 	os.Args = split("./example")
 
 	var args struct {
-		Foo string
+		Foo string `default:"abc"`
 	}
-	args.Foo = "default value"
 	MustParse(&args)
 	fmt.Println(args.Foo)
-	// output: default value
+	// output: abc
 }
 
 // This example demonstrates arguments that are required

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/alexflint/go-scalar v1.0.0
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,3 @@ require (
 	github.com/alexflint/go-scalar v1.0.0
 	github.com/stretchr/testify v1.2.2
 )
-
-go 1.13

--- a/parse.go
+++ b/parse.go
@@ -201,7 +201,7 @@ func NewParser(config Config, dests ...interface{}) (*Parser, error) {
 				if defaultVal, ok := v.Interface().(encoding.TextMarshaler); ok {
 					str, err := defaultVal.MarshalText()
 					if err != nil {
-						return nil, fmt.Errorf("%v: error marshaling default value to string: %w", spec.dest, err)
+						return nil, fmt.Errorf("%v: error marshaling default value to string: %v", spec.dest, err)
 					}
 					spec.defaultVal = string(str)
 				} else {

--- a/parse.go
+++ b/parse.go
@@ -55,7 +55,7 @@ type spec struct {
 	help       string
 	env        string
 	boolean    bool
-	defaultVal string // default value for this option, only if provided as a struct tag
+	defaultVal string // default value for this option
 }
 
 // command represents a named subcommand, or the top-level command
@@ -733,6 +733,5 @@ func isZero(v reflect.Value) bool {
 	if !t.Comparable() {
 		return false
 	}
-	z := reflect.Zero(t)
-	return v.Interface() == z.Interface()
+	return v.Interface() == reflect.Zero(t).Interface()
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1057,3 +1057,71 @@ func TestMultipleTerminates(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, args.X)
 	assert.Equal(t, "c", args.Y)
 }
+
+func TestDefaultOptionValues(t *testing.T) {
+	var args struct {
+		A int      `default:"123"`
+		B *int     `default:"123"`
+		C string   `default:"abc"`
+		D *string  `default:"abc"`
+		E float64  `default:"1.23"`
+		F *float64 `default:"1.23"`
+		G bool     `default:"true"`
+		H *bool    `default:"true"`
+	}
+
+	err := parse("--c=xyz --e=4.56", &args)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, args.A)
+	assert.Equal(t, 123, *args.B)
+	assert.Equal(t, "xyz", args.C)
+	assert.Equal(t, "abc", *args.D)
+	assert.Equal(t, 4.56, args.E)
+	assert.Equal(t, 1.23, *args.F)
+	assert.True(t, args.G)
+	assert.True(t, args.G)
+}
+
+func TestDefaultPositionalValues(t *testing.T) {
+	var args struct {
+		A int      `arg:"positional" default:"123"`
+		B *int     `arg:"positional" default:"123"`
+		C string   `arg:"positional" default:"abc"`
+		D *string  `arg:"positional" default:"abc"`
+		E float64  `arg:"positional" default:"1.23"`
+		F *float64 `arg:"positional" default:"1.23"`
+		G bool     `arg:"positional" default:"true"`
+		H *bool    `arg:"positional" default:"true"`
+	}
+
+	err := parse("456 789", &args)
+	require.NoError(t, err)
+
+	assert.Equal(t, 456, args.A)
+	assert.Equal(t, 789, *args.B)
+	assert.Equal(t, "abc", args.C)
+	assert.Equal(t, "abc", *args.D)
+	assert.Equal(t, 1.23, args.E)
+	assert.Equal(t, 1.23, *args.F)
+	assert.True(t, args.G)
+	assert.True(t, args.G)
+}
+
+func TestDefaultValuesNotAllowedWithRequired(t *testing.T) {
+	var args struct {
+		A int `arg:"required" default:"123"` // required not allowed with default!
+	}
+
+	err := parse("", &args)
+	assert.EqualError(t, err, ".A: 'required' cannot be used when a default value is specified")
+}
+
+func TestDefaultValuesNotAllowedWithSlice(t *testing.T) {
+	var args struct {
+		A []int `default:"123"` // required not allowed with default!
+	}
+
+	err := parse("", &args)
+	assert.EqualError(t, err, ".A: default values are not supported for slice fields")
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1083,6 +1083,15 @@ func TestDefaultOptionValues(t *testing.T) {
 	assert.True(t, args.G)
 }
 
+func TestDefaultUnparseable(t *testing.T) {
+	var args struct {
+		A int `default:"x"`
+	}
+
+	err := parse("", &args)
+	assert.EqualError(t, err, `error processing default value for --a: strconv.ParseInt: parsing "x": invalid syntax`)
+}
+
 func TestDefaultPositionalValues(t *testing.T) {
 	var args struct {
 		A int      `arg:"positional" default:"123"`


### PR DESCRIPTION
This pr introduces support for default values specified as struct tags:

```go
var args struct {
  Foo int `default:"123"`
}
arg.MustParse(&args)
```

This means there are now two ways to provide default values. The old way still works as expected:
```go
var args struct {
  Foo int
}
args.Foo = 123
arg.MustParse(&args)
```

The reason I'm introducing this feature is that it has now been requested many times, and the old approach does not work with subcommands (introduced in #82; see discussion in #86).

Fixes #40 #68 #86 #92 