### PR TITLE
Add support for custom, struct-wide field renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,26 @@ $ ./example
 main.NameDotName{Head:"file", Tail:"txt"}
 ```
 
+## Custom field renaming
+
+By default, struct field names are converted to a long argument by converting to all lowercase and an environment variable by converting to all uppercase. That behavior can customized by implementing the `Renamer` interface:
+
+```go
+type args struct {
+	SomeField string `arg:"env"`
+}
+
+func (args) RenameLong(field string) string {
+	return strcase.ToKebab(field)
+}
+
+func (args) RenameEnv(field string) string {
+	return strcase.ToScreamingSnake(field)
+}
+```
+
+In this example, the long argument name becomes `--some-field` and the environment variable becomes `SOME_FIELD`.
+
 ### Description strings
 
 ```go

--- a/parse_test.go
+++ b/parse_test.go
@@ -1134,3 +1134,33 @@ func TestDefaultValuesNotAllowedWithSlice(t *testing.T) {
 	err := parse("", &args)
 	assert.EqualError(t, err, ".A: default values are not supported for slice fields")
 }
+
+type customRenamerArgs struct {
+	SomeField string `arg:"env"`
+}
+
+func (r customRenamerArgs) RenameLong(field string) string {
+	return "long-" + field
+}
+func (r customRenamerArgs) RenameEnv(field string) string {
+	return "env-" + field
+}
+
+func TestRenamerLong(t *testing.T) {
+	var args customRenamerArgs
+
+	err := parse("--long-SomeField someLongValue", &args)
+	require.NoError(t, err)
+
+	assert.Equal(t, "someLongValue", args.SomeField)
+}
+
+func TestRenamerEnv(t *testing.T) {
+	var args customRenamerArgs
+
+	setenv(t, "env-SomeField", "someEnvValue")
+	err := parse("", &args)
+	require.NoError(t, err)
+
+	assert.Equal(t, "someEnvValue", args.SomeField)
+}


### PR DESCRIPTION
Unlike the examples that use "single word" field names, I tend to find in practice that my argument struct field names are multi-word names like `FromGitRepo`. The default naming conversion of `--fromgitrepo` doesn't read well, so I find I end up adding an arg tag to a lot of fields to fix up the multi-word naming. 

I prefer your library over others because it eliminates a lot of tediousness, so in this PR I propose a way of allowing end users to implement a struct-wide field renaming customization. A common convention is `kebab-case` for long argument names and `SCREAMING_SNAKE_CASE` for environment variables, but letting the end user implement the renaming avoids forcing any one convention on all users.

A new interface was added, `Renamer`, that follows in the customization strategy of `Versioned` and `Described`.

I added a section to the README that gives an example of using [iancoleman/strcase](https://github.com/iancoleman/strcase) to perform the kebab and snake case conversion mentioned above.

Feel free to decline this PR if it doesn't fit with strategies you have in mind for the library. For example, the solution described in https://github.com/alexflint/go-arg/issues/67 could be another way to accommodate multi-word arguments.