### PR TITLE
Subcommand usage options

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -235,7 +235,8 @@ func Example_helpTextForSubcommand() {
 	// Positional arguments:
 	//   ITEM                   item to fetch
 	//
-	// Options:
+	// Global options:
+	//   --verbose
 	//   --help, -h             display this help and exit
 }
 

--- a/usage.go
+++ b/usage.go
@@ -144,9 +144,29 @@ func (p *Parser) writeHelpForCommand(w io.Writer, cmd *command) {
 	}
 
 	// write the list of options
-	fmt.Fprint(w, "\nOptions:\n")
-	for _, spec := range options {
-		p.printOption(w, spec)
+	if len(options) > 0 || cmd.parent == nil {
+		fmt.Fprint(w, "\nOptions:\n")
+		for _, spec := range options {
+			p.printOption(w, spec)
+		}
+	}
+
+	// obtain a flattened list of options from all ancestors
+	var globals []*spec
+	ancestor := cmd.parent
+	for ancestor != nil {
+		for _, spec := range ancestor.specs {
+			globals = append(globals, spec)
+		}
+		ancestor = ancestor.parent
+	}
+
+	// write the list of global options
+	if len(globals) > 0 {
+		fmt.Fprint(w, "\nGlobal options:\n")
+		for _, spec := range globals {
+			p.printOption(w, spec)
+		}
 	}
 
 	// write the list of built in options

--- a/usage.go
+++ b/usage.go
@@ -163,9 +163,7 @@ func (p *Parser) writeHelpForCommand(w io.Writer, cmd *command) {
 	var globals []*spec
 	ancestor := cmd.parent
 	for ancestor != nil {
-		for _, spec := range ancestor.specs {
-			globals = append(globals, spec)
-		}
+		globals = append(globals, ancestor.specs...)
 		ancestor = ancestor.parent
 	}
 

--- a/usage.go
+++ b/usage.go
@@ -27,7 +27,11 @@ func (p *Parser) failWithCommand(msg string, cmd *command) {
 
 // WriteUsage writes usage information to the given writer
 func (p *Parser) WriteUsage(w io.Writer) {
-	p.writeUsageForCommand(w, p.cmd)
+	cmd := p.cmd
+	if p.lastCmd != nil {
+		cmd = p.lastCmd
+	}
+	p.writeUsageForCommand(w, cmd)
 }
 
 // writeUsageForCommand writes usage information for the given subcommand
@@ -116,7 +120,11 @@ func printTwoCols(w io.Writer, left, help string, defaultVal string) {
 
 // WriteHelp writes the usage string followed by the full help string for each option
 func (p *Parser) WriteHelp(w io.Writer) {
-	p.writeHelpForCommand(w, p.cmd)
+	cmd := p.cmd
+	if p.lastCmd != nil {
+		cmd = p.lastCmd
+	}
+	p.writeHelpForCommand(w, cmd)
 }
 
 // writeHelp writes the usage string for the given subcommand

--- a/usage_test.go
+++ b/usage_test.go
@@ -301,7 +301,7 @@ Global options:
 	p, err := NewParser(Config{}, &args)
 	require.NoError(t, err)
 
-	err = p.Parse([]string{"child", "nested", "value"})
+	_ = p.Parse([]string{"child", "nested", "value"})
 
 	var help bytes.Buffer
 	p.WriteHelp(&help)


### PR DESCRIPTION
Fixes #101 

Includes a change to the semantics of `WriteUsage` and `WriteHelp`. In particular, you can now call `p.Parse(args)` in a manner which includes a subcommand, and then the writers will pick up on that and print the help for the subcommand text instead.

This was needed to write a sane unit test for the usage fix, but it also seemed like a reasonable piece of functionality to add.

I don't think this should break userland, since relying on `p.Parse([]string{"subcommand"})` to _not_ update the WriteHelp/WriteUsage text would be batty. Still, if you have any concerns there, cecb4be is self-contained and can be taken alone.