### PR TITLE
Option to ignore environment variables

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -120,7 +120,11 @@ func flags() []string {
 
 // Config represents configuration options for an argument parser
 type Config struct {
-	Program string // Program is the name of the program used in the help text
+	// Program is the name of the program used in the help text
+	Program string
+
+	// IgnoreEnv instructs the library not to read environment variables
+	IgnoreEnv bool
 }
 
 // Parser represents a set of command line options with destination values
@@ -479,9 +483,11 @@ func (p *Parser) process(args []string) error {
 	copy(specs, curCmd.specs)
 
 	// deal with environment vars
-	err := p.captureEnvVars(specs, wasPresent)
-	if err != nil {
-		return err
+	if !p.config.IgnoreEnv {
+		err := p.captureEnvVars(specs, wasPresent)
+		if err != nil {
+			return err
+		}
 	}
 
 	// process each string from the command line
@@ -517,9 +523,11 @@ func (p *Parser) process(args []string) error {
 			specs = append(specs, subcmd.specs...)
 
 			// capture environment vars for these new options
-			err := p.captureEnvVars(subcmd.specs, wasPresent)
-			if err != nil {
-				return err
+			if !p.config.IgnoreEnv {
+				err := p.captureEnvVars(subcmd.specs, wasPresent)
+				if err != nil {
+					return err
+				}
 			}
 
 			curCmd = subcmd

--- a/parse_test.go
+++ b/parse_test.go
@@ -676,6 +676,36 @@ func TestEnvironmentVariableSliceArgumentWrongType(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEnvironmentVariableIgnored(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env"`
+	}
+	setenv(t, "FOO", "abc")
+
+	p, err := NewParser(Config{IgnoreEnv: true}, &args)
+	require.NoError(t, err)
+
+	err = p.Parse(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "", args.Foo)
+}
+
+func TestEnvironmentVariableInSubcommandIgnored(t *testing.T) {
+	var args struct {
+		Sub *struct {
+			Foo string `arg:"env"`
+		} `arg:"subcommand"`
+	}
+	setenv(t, "FOO", "abc")
+
+	p, err := NewParser(Config{IgnoreEnv: true}, &args)
+	require.NoError(t, err)
+
+	err = p.Parse([]string{"sub"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", args.Sub.Foo)
+}
+
 type textUnmarshaler struct {
 	val int
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -72,7 +72,7 @@ Options:
 	args.Value = 42
 	args.Values = []float64{3.14, 42, 256}
 	args.File = &NameDotName{"scratch", "txt"}
-	p, err := NewParser(Config{"example"}, &args)
+	p, err := NewParser(Config{Program: "example"}, &args)
 	require.NoError(t, err)
 
 	os.Args[0] = "example"
@@ -109,7 +109,7 @@ Options:
 		Content string `default:"dog"`
 	}
 	args.Label = "cat"
-	p, err := NewParser(Config{"example"}, &args)
+	p, err := NewParser(Config{Program: "example"}, &args)
 	require.NoError(t, err)
 
 	args.Label = "should_ignore_this"
@@ -125,7 +125,7 @@ func TestUsageCannotMarshalToString(t *testing.T) {
 	}
 	v := MyEnum(42)
 	args.Name = &v
-	_, err := NewParser(Config{"example"}, &args)
+	_, err := NewParser(Config{Program: "example"}, &args)
 	assert.EqualError(t, err, `args.Name: error marshaling default value to string: There was a problem`)
 }
 


### PR DESCRIPTION
This pr adds a boolean flag `IgnoreEnv` to the `Config` struct, which can be used to turn off all environment variable processing, as this test demonstrates:

```go
func TestEnvironmentVariableIgnored(t *testing.T) {
	var args struct {
		Foo string `arg:"env"`
	}
	setenv(t, "FOO", "abc")

	p, err := NewParser(Config{IgnoreEnv: true}, &args)
	require.NoError(t, err)

	err = p.Parse(nil)
	assert.NoError(t, err)
	assert.Equal(t, "", args.Foo)
}
```

Closes #95 