### PR TITLE
Allow conditionally required members

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ $ ./example
 Usage: example --id ID [--timeout TIMEOUT]
 error: --id is required
 ```
+### Conditional required arguments
+
+```go
+var args struct {
+	UserName      string `default:"abc"`
+	UserID        string `default:"123"`
+	Password      string `arg:"required-if:username|userid"`
+}
+arg.MustParse(&args)
+```
+
+```shell
+$ ./example --username=happytimes
+Usage: example --id ID [--timeout TIMEOUT]
+error: --password is required, because: 
+			username was set
+```
 
 ### Positional arguments
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -1249,15 +1249,6 @@ func TestMissingRequiredIf(t *testing.T) {
 	err := parse("x", &args)
 	assert.Error(t, err)
 }
-func TestEnvironmentVariableRequiredIf(t *testing.T) {
-	var args struct {
-		Foo string `arg:"env,required-if:dummy"`
-	}
-	setenv(t, "FOO", "bar")
-	os.Args = []string{"example"}
-	MustParse(&args)
-	assert.Equal(t, "bar", args.Foo)
-}
 
 func TestDefaultPositionalRequiredIfValues(t *testing.T) {
 	var args struct {
@@ -1303,4 +1294,5 @@ func TestRequiredIfValues(t *testing.T) {
 	assert.Equal(t, 1.23, *args.F)
 	assert.True(t, args.G)
 	assert.NotNil(t, args.H)
+	assert.True(t, *args.H)
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -251,16 +251,26 @@ Options:
 }
 
 func TestRequiredMultiplePositionals(t *testing.T) {
-	expectedHelp := `Usage: example REQUIREDMULTIPLE [REQUIREDMULTIPLE ...]
+	expectedHelp := `Usage: go-arg.test [--makerequired MAKEREQUIRED] [--requiredvariable REQUIREDVARIABLE] REQUIREDMULTIPLE [REQUIREDMULTIPLE ...]
+
+Required arguments:
+  REQUIREDMULTIPLE       required multiple positional
+
+Conditionally required arguments:
+  REQUIREDVARIABLE       required if: makerequired has be set
 
 Positional arguments:
   REQUIREDMULTIPLE       required multiple positional
 
 Options:
+  --makerequired MAKEREQUIRED [default: dog]
+  --requiredvariable REQUIREDVARIABLE
   --help, -h             display this help and exit
 `
 	var args struct {
 		RequiredMultiple []string `arg:"positional,required" help:"required multiple positional"`
+		MakeRequired     string   `default:"dog"`
+		RequiredVariable string   `arg:"required-if:makerequired|"`
 	}
 
 	p, err := NewParser(Config{}, &args)
@@ -271,8 +281,11 @@ Options:
 	assert.Equal(t, expectedHelp, help.String())
 }
 
-func TestUsageWithNestedSubcommands(t *testing.T) {
+func TestUsagWithNestedSubcommands(t *testing.T) {
 	expectedHelp := `Usage: example child nested [--enable] OUTPUT
+
+Required arguments:
+  OUTPUT
 
 Positional arguments:
   OUTPUT

--- a/usage_test.go
+++ b/usage_test.go
@@ -251,7 +251,7 @@ Options:
 }
 
 func TestRequiredMultiplePositionals(t *testing.T) {
-	expectedHelp := `Usage: go-arg.test [--makerequired MAKEREQUIRED] [--requiredvariable REQUIREDVARIABLE] REQUIREDMULTIPLE [REQUIREDMULTIPLE ...]
+	expectedHelp := `Usage: example [--makerequired MAKEREQUIRED] [--requiredvariable REQUIREDVARIABLE] REQUIREDMULTIPLE [REQUIREDMULTIPLE ...]
 
 Required arguments:
   REQUIREDMULTIPLE       required multiple positional


### PR DESCRIPTION
This PR introduces support for variables that maybe conditionally:
 ``` go
var args struct {
	UserName   string `default:"abc"`
	UserID     string `default:"123"`
	Password   string `arg:"required-if:username|userid"`
}
arg.MustParse(&args)
```
This will enable users to express the relationship between variables. This feature is most important for featured flagged capabilities where if a feature is turned on another variable should be set in order to work correctly. 