### PR TITLE
feat(usage): Include env variable in usage

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -101,7 +101,7 @@ func (p *Parser) writeUsageForCommand(w io.Writer, cmd *command) {
 	fmt.Fprint(w, "\n")
 }
 
-func printTwoCols(w io.Writer, left, help string, defaultVal string) {
+func printTwoCols(w io.Writer, left, help string, defaultVal string, envVal string) {
 	lhs := "  " + left
 	fmt.Fprint(w, lhs)
 	if help != "" {
@@ -112,8 +112,23 @@ func printTwoCols(w io.Writer, left, help string, defaultVal string) {
 		}
 		fmt.Fprint(w, help)
 	}
+
+	bracketsContent := []string{}
+
 	if defaultVal != "" {
-		fmt.Fprintf(w, " [default: %s]", defaultVal)
+		bracketsContent = append(bracketsContent,
+			fmt.Sprintf("default: %s", defaultVal),
+		)
+	}
+
+	if envVal != "" {
+		bracketsContent = append(bracketsContent,
+			fmt.Sprintf("env: %s", envVal),
+		)
+	}
+
+	if len(bracketsContent) > 0 {
+		fmt.Fprintf(w, " [%s]", strings.Join(bracketsContent, ", "))
 	}
 	fmt.Fprint(w, "\n")
 }
@@ -147,7 +162,7 @@ func (p *Parser) writeHelpForCommand(w io.Writer, cmd *command) {
 	if len(positionals) > 0 {
 		fmt.Fprint(w, "\nPositional arguments:\n")
 		for _, spec := range positionals {
-			printTwoCols(w, spec.placeholder, spec.help, "")
+			printTwoCols(w, spec.placeholder, spec.help, "", "")
 		}
 	}
 
@@ -194,7 +209,7 @@ func (p *Parser) writeHelpForCommand(w io.Writer, cmd *command) {
 	if len(cmd.subcommands) > 0 {
 		fmt.Fprint(w, "\nCommands:\n")
 		for _, subcmd := range cmd.subcommands {
-			printTwoCols(w, subcmd.name, subcmd.help, "")
+			printTwoCols(w, subcmd.name, subcmd.help, "", "")
 		}
 	}
 }
@@ -204,7 +219,7 @@ func (p *Parser) printOption(w io.Writer, spec *spec) {
 	if spec.short != "" {
 		left += ", " + synopsis(spec, "-"+spec.short)
 	}
-	printTwoCols(w, left, spec.help, spec.defaultVal)
+	printTwoCols(w, left, spec.help, spec.defaultVal, spec.env)
 }
 
 func synopsis(spec *spec, form string) string {

--- a/usage_test.go
+++ b/usage_test.go
@@ -33,9 +33,9 @@ func (n *NameDotName) MarshalText() (text []byte, err error) {
 }
 
 func TestWriteUsage(t *testing.T) {
-	expectedUsage := "Usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--values VALUES] [--workers WORKERS] [--file FILE] INPUT [OUTPUT [OUTPUT ...]]\n"
+	expectedUsage := "Usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--values VALUES] [--workers WORKERS] [--testenv TESTENV] [--file FILE] INPUT [OUTPUT [OUTPUT ...]]\n"
 
-	expectedHelp := `Usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--values VALUES] [--workers WORKERS] [--file FILE] INPUT [OUTPUT [OUTPUT ...]]
+	expectedHelp := `Usage: example [--name NAME] [--value VALUE] [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] [--ids IDS] [--values VALUES] [--workers WORKERS] [--testenv TESTENV] [--file FILE] INPUT [OUTPUT [OUTPUT ...]]
 
 Positional arguments:
   INPUT
@@ -51,7 +51,8 @@ Options:
   --ids IDS              Ids
   --values VALUES        Values [default: [3.14 42 256]]
   --workers WORKERS, -w WORKERS
-                         number of workers to start
+                         number of workers to start [default: 10, env: WORKERS]
+  --testenv TESTENV, -a TESTENV [env: TEST_ENV]
   --file FILE, -f FILE   File with mandatory extension [default: scratch.txt]
   --help, -h             display this help and exit
 `
@@ -65,7 +66,8 @@ Options:
 		Optimize int          `arg:"-O" help:"optimization level"`
 		Ids      []int64      `help:"Ids"`
 		Values   []float64    `help:"Values"`
-		Workers  int          `arg:"-w,env:WORKERS" help:"number of workers to start"`
+		Workers  int          `arg:"-w,env:WORKERS" help:"number of workers to start" default:"10"`
+		TestEnv  string       `arg:"-a,env:TEST_ENV"`
 		File     *NameDotName `arg:"-f" help:"File with mandatory extension"`
 	}
 	args.Name = "Foo Bar"


### PR DESCRIPTION
The test case should be self-explanatory: this PR adds displaying of ENV variables in the usage output, so that one doesn't have to look at the code (which may not be provided) to understand which environment variables are accepted.