### PR TITLE
Add examples showing how to override the short and long versions of option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Workers: [1 99]
 var args struct {
 	Input    string   `arg:"positional"`
 	Output   []string `arg:"positional"`
-	Verbose  bool     `arg:"-v" help:"verbosity level"`
+	Verbose  bool     `arg:"-v,--verbose" help:"verbosity level"`
 	Dataset  string   `help:"dataset to use"`
 	Optimize int      `arg:"-O" help:"optimization level"`
 }
@@ -239,6 +239,29 @@ func main() {
 $ ./example --version
 someprogram 4.3.0
 ```
+
+### Overriding option names
+
+```go
+var args struct {
+	Short         string  `arg:"-s"`
+	Long          string  `arg:"--custom-long-option"`
+	ShortAndLong  string  `arg:"-x,--my-option"`
+}
+arg.MustParse(&args)
+```
+
+```shell
+$ ./example --help
+Usage: [--short SHORT] [--custom-long-option CUSTOM-LONG-OPTION] [--my-option MY-OPTION]
+
+Options:
+  --short SHORT, -s SHORT
+  --custom-long-option CUSTOM-LONG-OPTION
+  --my-option MY-OPTION, -x MY-OPTION
+  --help, -h             display this help and exit
+```
+
 
 ### Embedded structs
 

--- a/example_test.go
+++ b/example_test.go
@@ -112,7 +112,7 @@ func Example_helpText() {
 		Output   []string `arg:"positional"`
 		Verbose  bool     `arg:"-v" help:"verbosity level"`
 		Dataset  string   `help:"dataset to use"`
-		Optimize int      `arg:"-O,help:optimization level"`
+		Optimize int      `arg:"-O,--optim" help:"optimization level"`
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
@@ -121,7 +121,7 @@ func Example_helpText() {
 	MustParse(&args)
 
 	// output:
-	// Usage: example [--verbose] [--dataset DATASET] [--optimize OPTIMIZE] INPUT [OUTPUT [OUTPUT ...]]
+	// Usage: example [--verbose] [--dataset DATASET] [--optim OPTIM] INPUT [OUTPUT [OUTPUT ...]]
 	//
 	// Positional arguments:
 	//   INPUT
@@ -130,7 +130,7 @@ func Example_helpText() {
 	// Options:
 	//   --verbose, -v          verbosity level
 	//   --dataset DATASET      dataset to use
-	//   --optimize OPTIMIZE, -O OPTIMIZE
+	//   --optim OPTIM, -O OPTIM
 	//                          optimization level
 	//   --help, -h             display this help and exit
 }


### PR DESCRIPTION
This pr adds documentation and examples showing that it is possible to override either the short option name (-s), the long option name (--long), or both ("-s,--long"). 

Closes #121 