### PR TITLE
Optional long names

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,21 +244,23 @@ someprogram 4.3.0
 
 ```go
 var args struct {
-	Short         string  `arg:"-s"`
-	Long          string  `arg:"--custom-long-option"`
-	ShortAndLong  string  `arg:"-x,--my-option"`
+	Short        string `arg:"-s"`
+	Long         string `arg:"--custom-long-option"`
+	ShortAndLong string `arg:"-x,--my-option"`
+	OnlyShort    string `arg:"-o,--"`
 }
 arg.MustParse(&args)
 ```
 
 ```shell
 $ ./example --help
-Usage: [--short SHORT] [--custom-long-option CUSTOM-LONG-OPTION] [--my-option MY-OPTION]
+Usage: example [-o ONLYSHORT] [--short SHORT] [--custom-long-option CUSTOM-LONG-OPTION] [--my-option MY-OPTION]
 
 Options:
   --short SHORT, -s SHORT
   --custom-long-option CUSTOM-LONG-OPTION
   --my-option MY-OPTION, -x MY-OPTION
+  -o ONLYSHORT
   --help, -h             display this help and exit
 ```
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -231,6 +231,18 @@ func TestPlaceholder(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoLongName(t *testing.T) {
+	var args struct {
+		ShortOnly string `arg:"-s,--"`
+		EnvOnly   string `arg:"--,env"`
+	}
+	setenv(t, "ENVONLY", "TestVal")
+	err := parse("-s TestVal2", &args)
+	assert.NoError(t, err)
+	assert.Equal(t, "TestVal", args.EnvOnly)
+	assert.Equal(t, "TestVal2", args.ShortOnly)
+}
+
 func TestCaseSensitive(t *testing.T) {
 	var args struct {
 		Lower bool `arg:"-v"`

--- a/usage.go
+++ b/usage.go
@@ -117,6 +117,9 @@ func (p *Parser) writeUsageForCommand(w io.Writer, cmd *command) {
 }
 
 func printTwoCols(w io.Writer, left, help string, defaultVal string, envVal string) {
+	if left == "" {
+		return
+	}
 	lhs := "  " + left
 	fmt.Fprint(w, lhs)
 	if help != "" {

--- a/usage_test.go
+++ b/usage_test.go
@@ -309,3 +309,22 @@ Global options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+func TestUsageWithOptionalLongNames(t *testing.T) {
+	expectedHelp := `Usage: example [-a PLACEHOLDER] -b SHORTONLY2
+
+Options:
+  -a PLACEHOLDER         some help [default: some val]
+  -b SHORTONLY2          some help2
+  --help, -h             display this help and exit
+`
+	var args struct {
+		ShortOnly  string `arg:"-a,--" help:"some help" default:"some val" placeholder:"PLACEHOLDER"`
+		ShortOnly2 string `arg:"-b,--,required" help:"some help2"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -328,3 +328,23 @@ Options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+func TestUsageWithEnvOptions(t *testing.T) {
+	expectedHelp := `Usage: example [-s SHORT]
+
+Options:
+  -s SHORT [env: SHORT]
+  --help, -h             display this help and exit
+`
+	var args struct {
+		Short            string `arg:"--,-s,env"`
+		EnvOnly          string `arg:"--,env"`
+		EnvOnlyOverriden string `arg:"--,env:CUSTOM"`
+	}
+
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}


### PR DESCRIPTION
A couple of questions:

* I've extracted short-name-only options to the beginning of the usage string (following the example of other CLI help messages).
- [x] OK
- [ ] No, print in order declaration
* Should I also add short name flag grouping? `example -abc` == `example -a -b -c`
- [ ] Yes
- [x] No

I also stumbled onto a bug (?): subcommand's Description() is ignored, only the main command's description will be displayed:
```
$ example --help
Main Description

$ example subcommand --help
Main Description
```
It probably should display the subcommand's description.
- [ ] Include the parent's description
- [x] or replace it?

Currently, the env names depend on the field name, not long name (like placeholder text). Is it
- [x] intentional
- [ ] or maybe we should use long names (processed a bit: `--long-name` -> `LONG_NAME`)?

Suggestion: parser option to configure printing env variable names in the option description:
`PrintNone`, `PrintAll`. `PrintOverriden`(default) for the command line options

`PrintEnvOnlyVars` - for environment-only options (can be ORed with other options). It lists name, help, and the default value in a manner similar to the CLI options. Some Ideas:
```golang
var args struct {
	Short            string `arg:"--,-s,env"`
	EnvOnly          string `arg:"--,env" help:"like this"`
	EnvOnlyOverriden string `arg:"--,env:CUSTOM" help:"or like this"`
	EnvOnlyAgain     string `arg:"--,env:OTHER_NAME" help:"or maybe like this"`
}
```

```shell
$ ./example --help
Usage: example [-s SHORT]

Options:
  -s SHORT [env: SHORT]
  env: ENVONLY           like this
  [CUSTOM]               or like this
  --help, -h             display this help and exit

Environment variables:
  OTHER_NAME             or maybe like this
```
