### PR TITLE
Ignore unexported fields

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -242,6 +242,14 @@ func NewParser(config Config, dests ...interface{}) (*Parser, error) {
 	return &p, nil
 }
 
+// isUnexportedField determines if a struct field is exported or unexported by its name
+func isUnexportedField(fieldName string) bool {
+	if len(fieldName) > 0 && unicode.IsLetter(rune(fieldName[0])) && unicode.IsLower(rune(fieldName[0])) {
+		return true
+	}
+	return false
+}
+
 func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 	// commands can only be created from pointers to structs
 	if t.Kind() != reflect.Ptr {
@@ -264,7 +272,7 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 	walkFields(t, func(field reflect.StructField, t reflect.Type) bool {
 		// Check for the ignore switch in the tag
 		tag := field.Tag.Get("arg")
-		if tag == "-" || (unicode.IsLetter(rune(field.Name[0])) && unicode.IsLower(rune(field.Name[0]))) {
+		if tag == "-" || isUnexportedField(field.Name) {
 			return false
 		}
 

--- a/parse.go
+++ b/parse.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"unicode"
 
 	scalar "github.com/alexflint/go-scalar"
 )
@@ -263,7 +264,7 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 	walkFields(t, func(field reflect.StructField, t reflect.Type) bool {
 		// Check for the ignore switch in the tag
 		tag := field.Tag.Get("arg")
-		if tag == "-" {
+		if tag == "-" || (unicode.IsLetter(rune(field.Name[0])) && unicode.IsLower(rune(field.Name[0]))) {
 			return false
 		}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -1213,3 +1213,12 @@ func TestDefaultValuesNotAllowedWithSlice(t *testing.T) {
 	err := parse("", &args)
 	assert.EqualError(t, err, ".A: default values are not supported for slice fields")
 }
+
+func TestUnexportedFields(t *testing.T) {
+	var args struct {
+		a string
+	}
+
+	err := parse("", &args)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
This change prevents fields that are unexported (start with a lowercase letter) from being processed by the package. This prevents a reflection error.

It does not cause any backwards compatibility issues with the existing codebase because with the current code you received an error if an unexported field exists on the arguments struct. This change prevents that error allowing the rest of the struct to be processed by skipping the unexported field.

A fix for issue #132 