### PR TITLE
Skip unexported fields

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -263,7 +263,7 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 	walkFields(t, func(field reflect.StructField, t reflect.Type) bool {
 		// Check for the ignore switch in the tag
 		tag := field.Tag.Get("arg")
-		if tag == "-" {
+		if tag == "-" || !isExported(field.Name) {
 			return false
 		}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -1213,3 +1213,12 @@ func TestDefaultValuesNotAllowedWithSlice(t *testing.T) {
 	err := parse("", &args)
 	assert.EqualError(t, err, ".A: default values are not supported for slice fields")
 }
+
+func TestUnexportedFieldsSkipped(t *testing.T) {
+	var args struct {
+		unexported struct{}
+	}
+
+	_, err := NewParser(Config{}, &args)
+	require.NoError(t, err)
+}

--- a/reflect.go
+++ b/reflect.go
@@ -3,6 +3,8 @@ package arg
 import (
 	"encoding"
 	"reflect"
+	"unicode"
+	"unicode/utf8"
 
 	scalar "github.com/alexflint/go-scalar"
 )
@@ -59,4 +61,10 @@ func isBoolean(t reflect.Type) bool {
 	default:
 		return false
 	}
+}
+
+// isExported returns true if the struct field name is exported
+func isExported(field string) bool {
+	r, _ := utf8.DecodeRuneInString(field) // returns RuneError for empty string or invalid UTF8
+	return unicode.IsLetter(r) && unicode.IsUpper(r)
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -53,3 +53,10 @@ func TestCanParseTextUnmarshaler(t *testing.T) {
 	assertCanParse(t, reflect.TypeOf(su), true, false, true)
 	assertCanParse(t, reflect.TypeOf(&su), true, false, true)
 }
+
+func TestIsExported(t *testing.T) {
+	assert.True(t, isExported("Exported"))
+	assert.False(t, isExported("notExported"))
+	assert.False(t, isExported(""))
+	assert.False(t, isExported(string([]byte{255})))
+}


### PR DESCRIPTION
Fixes #132 

Do not process unexported struct fields.