### PR TITLE
Optional long names

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,21 +244,23 @@ someprogram 4.3.0
 
 ```go
 var args struct {
-	Short         string  `arg:"-s"`
-	Long          string  `arg:"--custom-long-option"`
-	ShortAndLong  string  `arg:"-x,--my-option"`
+	Short        string `arg:"-s"`
+	Long         string `arg:"--custom-long-option"`
+	ShortAndLong string `arg:"-x,--my-option"`
+	OnlyShort    string `arg:"-o,--"`
 }
 arg.MustParse(&args)
 ```
 
 ```shell
 $ ./example --help
-Usage: [--short SHORT] [--custom-long-option CUSTOM-LONG-OPTION] [--my-option MY-OPTION]
+Usage: example [-o ONLYSHORT] [--short SHORT] [--custom-long-option CUSTOM-LONG-OPTION] [--my-option MY-OPTION]
 
 Options:
   --short SHORT, -s SHORT
   --custom-long-option CUSTOM-LONG-OPTION
   --my-option MY-OPTION, -x MY-OPTION
+  -o ONLYSHORT
   --help, -h             display this help and exit
 ```
 

--- a/parse.go
+++ b/parse.go
@@ -47,7 +47,7 @@ func (p path) Child(f reflect.StructField) path {
 // spec represents a command line option
 type spec struct {
 	dest        path
-	field       reflect.StructField // name of struct field from this this option was created
+	field       reflect.StructField // the struct field from which this option was created
 	long        string              // the --long form for this option, or empty if none
 	short       string              // the -s short form for this option, or empty if none
 	multiple    bool

--- a/parse_test.go
+++ b/parse_test.go
@@ -231,6 +231,18 @@ func TestPlaceholder(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestNoLongName(t *testing.T) {
+	var args struct {
+		ShortOnly string `arg:"-s,--"`
+		EnvOnly   string `arg:"--,env"`
+	}
+	setenv(t, "ENVONLY", "TestVal")
+	err := parse("-s TestVal2", &args)
+	assert.NoError(t, err)
+	assert.Equal(t, "TestVal", args.EnvOnly)
+	assert.Equal(t, "TestVal2", args.ShortOnly)
+}
+
 func TestCaseSensitive(t *testing.T) {
 	var args struct {
 		Lower bool `arg:"-v"`

--- a/usage.go
+++ b/usage.go
@@ -117,6 +117,9 @@ func (p *Parser) writeUsageForCommand(w io.Writer, cmd *command) {
 }
 
 func printTwoCols(w io.Writer, left, help string, defaultVal string, envVal string) {
+	if left == "" {
+		return
+	}
 	lhs := "  " + left
 	fmt.Fprint(w, lhs)
 	if help != "" {

--- a/usage_test.go
+++ b/usage_test.go
@@ -309,3 +309,22 @@ Global options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+func TestUsageWithOptionalLongNames(t *testing.T) {
+	expectedHelp := `Usage: example [-a PLACEHOLDER] -b SHORTONLY2
+
+Options:
+  -a PLACEHOLDER         some help [default: some val]
+  -b SHORTONLY2          some help2
+  --help, -h             display this help and exit
+`
+	var args struct {
+		ShortOnly  string `arg:"-a,--" help:"some help" default:"some val" placeholder:"PLACEHOLDER"`
+		ShortOnly2 string `arg:"-b,--,required" help:"some help2"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -310,7 +310,7 @@ Global options:
 	assert.Equal(t, expectedHelp, help.String())
 }
 
-func TestUsageWithOptionalLongNames(t *testing.T) {
+func TestUsageWithoutLongNames(t *testing.T) {
 	expectedHelp := `Usage: example [-a PLACEHOLDER] -b SHORTONLY2
 
 Options:
@@ -321,6 +321,25 @@ Options:
 	var args struct {
 		ShortOnly  string `arg:"-a,--" help:"some help" default:"some val" placeholder:"PLACEHOLDER"`
 		ShortOnly2 string `arg:"-b,--,required" help:"some help2"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}
+
+func TestUsageWithShortFirst(t *testing.T) {
+	expectedHelp := `Usage: example [-c CAT] [--dog DOG]
+
+Options:
+  -c CAT
+  --dog DOG
+  --help, -h             display this help and exit
+`
+	var args struct {
+		Dog string
+		Cat string `arg:"-c,--"`
 	}
 	p, err := NewParser(Config{Program: "example"}, &args)
 	assert.NoError(t, err)

--- a/usage_test.go
+++ b/usage_test.go
@@ -328,3 +328,23 @@ Options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp, help.String())
 }
+
+func TestUsageWithEnvOptions(t *testing.T) {
+	expectedHelp := `Usage: example [-s SHORT]
+
+Options:
+  -s SHORT [env: SHORT]
+  --help, -h             display this help and exit
+`
+	var args struct {
+		Short            string `arg:"--,-s,env"`
+		EnvOnly          string `arg:"--,env"`
+		EnvOnlyOverriden string `arg:"--,env:CUSTOM"`
+	}
+
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp, help.String())
+}


### PR DESCRIPTION
(Pulling code written by @Andrew-Morozko over to a new branch in order to address comments.)

This PR makes it possible to have options that have short names but no long name, like this:
```go
var args struct {
  ShortOnly string `arg:"-s,--"`
}
```
This field will respond to "-s" on the command line but not to any double-dash long name.