### PR TITLE
Add go1.15 to CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.12', '1.13', '1.14', '1.15']
+        go: ['1.12', '1.13', '1.14', '1.15']
 
     steps:
     - id: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.11', '1.12', '1.13', '1.14']
+        go: [1.12', '1.13', '1.14', '1.15']
 
     steps:
     - id: go


### PR DESCRIPTION
This PR adds go1.15 to continuous integration, and drop go1.11