### PR TITLE
Add an example of mappings with commas

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -95,17 +95,30 @@ func Example_mappings() {
 	// output: map[john:123 mary:456]
 }
 
+type commaSeparated map[string]string
+
+func (c commaSeparated) UnmarshalText(b []byte) error {
+	for _, part := range strings.Split(string(b), ",") {
+		pos := strings.Index(part, "=")
+		if pos == -1 {
+			return fmt.Errorf("error parsing %q, expected format key=value", part)
+		}
+		c[part[:pos]] = part[pos+1:]
+	}
+	return nil
+}
+
 // This example demonstrates arguments with keys and values separated by commas
-func Example_mappingsWithCommas() {
+func Example_mappingWithCommas() {
 	// The args you would pass in on the command line
-	os.Args = split("./example --userids john=123 mary=456")
+	os.Args = split("./example --m one=two,three=four")
 
 	var args struct {
-		UserIDs map[string]int
+		M commaSeparated
 	}
 	MustParse(&args)
-	fmt.Println(args.UserIDs)
-	// output: map[john:123 mary:456]
+	fmt.Println(args.M)
+	// output: map[one:two three:four]
 }
 
 // This eample demonstrates multiple value arguments that can be mixed with

--- a/example_test.go
+++ b/example_test.go
@@ -95,15 +95,18 @@ func Example_mappings() {
 	// output: map[john:123 mary:456]
 }
 
-type commaSeparated map[string]string
+type commaSeparated struct {
+	M map[string]string
+}
 
-func (c commaSeparated) UnmarshalText(b []byte) error {
+func (c *commaSeparated) UnmarshalText(b []byte) error {
+	c.M = make(map[string]string)
 	for _, part := range strings.Split(string(b), ",") {
 		pos := strings.Index(part, "=")
 		if pos == -1 {
 			return fmt.Errorf("error parsing %q, expected format key=value", part)
 		}
-		c[part[:pos]] = part[pos+1:]
+		c.M[part[:pos]] = part[pos+1:]
 	}
 	return nil
 }
@@ -111,13 +114,13 @@ func (c commaSeparated) UnmarshalText(b []byte) error {
 // This example demonstrates arguments with keys and values separated by commas
 func Example_mappingWithCommas() {
 	// The args you would pass in on the command line
-	os.Args = split("./example --m one=two,three=four")
+	os.Args = split("./example --values one=two,three=four")
 
 	var args struct {
-		M commaSeparated
+		Values commaSeparated
 	}
 	MustParse(&args)
-	fmt.Println(args.M)
+	fmt.Println(args.Values.M)
 	// output: map[one:two three:four]
 }
 


### PR DESCRIPTION
This pr adds a runnable example of parsing values into a map when the key=value entries are separated by commas, as in:

```shell
./example --mymapping a=b,c=d,e=f
```
