### PR TITLE
Recurse into unexported embedded structs

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1095,6 +1095,29 @@ func TestEmbeddedWithDuplicateField2(t *testing.T) {
 	assert.Equal(t, "", args.U.A)
 }
 
+func TestUnexportedEmbedded(t *testing.T) {
+	type embeddedArgs struct {
+		Foo string
+	}
+	var args struct {
+		embeddedArgs
+	}
+	err := parse("--foo bar", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", args.Foo)
+}
+
+func TestIgnoredEmbedded(t *testing.T) {
+	type embeddedArgs struct {
+		Foo string
+	}
+	var args struct {
+		embeddedArgs `arg:"-"`
+	}
+	err := parse("--foo bar", &args)
+	require.Error(t, err)
+}
+
 func TestEmptyArgs(t *testing.T) {
 	origArgs := os.Args
 


### PR DESCRIPTION
Fixes #157 

This PR makes it so that exported fields on unexported embedded structs still show up as flags. This was a regression in v1.4.0. 