### PR TITLE
Add support for URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,22 @@ func main() {
 
 As usual, any field tagged with `arg:"-"` is ignored.
 
+### Supported types
+
+The following types may be used as arguments:
+- built-in integer types: `int, int8, int16, int32, int64, byte, rune`
+- built-in floating point types: `float32, float64`
+- strings
+- booleans
+- URLs represented as `url.URL`
+- time durations represented as `time.Duration`
+- email addresses represented as `mail.Address`
+- MAC addresses represented as `net.HardwareAddr`
+- pointers to any of the above
+- slices of any of the above
+- maps using any of the above as keys and values
+- any type that implements `encoding.TextUnmarshaler`
+
 ### Custom parsing
 
 Implement `encoding.TextUnmarshaler` to define your own parsing logic.

--- a/example_test.go
+++ b/example_test.go
@@ -2,8 +2,12 @@ package arg
 
 import (
 	"fmt"
+	"net"
+	"net/mail"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 func split(s string) []string {
@@ -376,4 +380,35 @@ func Example_subcommand() {
 
 	// output:
 	// commit requested with message "what-this-commit-is-about"
+}
+
+func Example_allSupportedTypes() {
+	// These are the args you would pass in on the command line
+	os.Args = []string{}
+
+	var args struct {
+		Bool     bool
+		Byte     byte
+		Rune     rune
+		Int      int
+		Int8     int8
+		Int16    int16
+		Int32    int32
+		Int64    int64
+		Float32  float32
+		Float64  float64
+		String   string
+		Duration time.Duration
+		URL      url.URL
+		Email    mail.Address
+		MAC      net.HardwareAddr
+	}
+
+	// go-arg supports each of the types above, as well as pointers to any of
+	// the above and slices of any of the above. It also supports any types that
+	// implements encoding.TextUnmarshaler.
+
+	MustParse(&args)
+
+	// output:
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/alexflint/go-arg
 
 require (
-	github.com/alexflint/go-scalar v1.0.0
+	github.com/alexflint/go-scalar v1.1.0
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
+github.com/alexflint/go-scalar v1.1.0 h1:aaAouLLzI9TChcPXotr6gUhq+Scr8rl0P9P4PnltbhM=
+github.com/alexflint/go-scalar v1.1.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/parse_test.go
+++ b/parse_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/mail"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -959,6 +960,24 @@ func TestPtrToIP(t *testing.T) {
 	err := parse("--host 192.168.0.1", &args)
 	require.NoError(t, err)
 	assert.Equal(t, "192.168.0.1", args.Host.String())
+}
+
+func TestURL(t *testing.T) {
+	var args struct {
+		URL url.URL
+	}
+	err := parse("--url https://example.com/get?item=xyz", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/get?item=xyz", args.URL.String())
+}
+
+func TestPtrToURL(t *testing.T) {
+	var args struct {
+		URL *url.URL
+	}
+	err := parse("--url http://example.com/#xyz", &args)
+	require.NoError(t, err)
+	assert.Equal(t, "http://example.com/#xyz", args.URL.String())
 }
 
 func TestIPSlice(t *testing.T) {


### PR DESCRIPTION
This pull request adds support parsing URLs:

```go
var args struct {
   URL url.URL
}
arg.MustParse(&args)
```

It also adds documentation about the full range of types supported by go-arg.

Closes #161 