### PR TITLE
Put name of environment variable in error message

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -653,7 +653,11 @@ func (p *Parser) process(args []string) error {
 		}
 
 		if spec.required {
-			return fmt.Errorf("%s is required", name)
+			msg := fmt.Sprintf("%s is required", name)
+			if spec.env != "" {
+				msg += " (or environment variable " + spec.env + ")"
+			}
+			return errors.New(msg)
 		}
 		if spec.defaultVal != "" {
 			err := scalar.ParseValue(p.val(spec.dest), spec.defaultVal)

--- a/parse_test.go
+++ b/parse_test.go
@@ -203,6 +203,14 @@ func TestRequired(t *testing.T) {
 	require.Error(t, err, "--foo is required")
 }
 
+func TestRequiredWithEnv(t *testing.T) {
+	var args struct {
+		Foo string `arg:"required,env:FOO"`
+	}
+	err := parse("", &args)
+	require.Error(t, err, "--foo is required (or environment variable FOO)")
+}
+
 func TestShortFlag(t *testing.T) {
 	var args struct {
 		Foo string `arg:"-f"`


### PR DESCRIPTION
Fixes #165 

This pull request adds the name of the relevant environment variable to error messages

```
NEW:
error: --foo is required (or environment variable FOO)

OLD:
error: --foo is required
```

If no environment variable is associated with an argument then nothing is changed in the error message.