### PR TITLE
Support Description() on subcommands

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -218,7 +218,15 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 		}
 	}
 
-	if p.description != "" {
+	var description string
+	if v := p.val(cmd.dest); v.IsValid() && !isZero(v) {
+		if d, ok := v.Interface().(Described); ok {
+			description = d.Description()
+		}
+	}
+	if description != "" {
+		fmt.Fprintln(w, description)
+	} else if p.description != "" {
 		fmt.Fprintln(w, p.description)
 	}
 	p.writeUsageForSubcommand(w, cmd)

--- a/usage_test.go
+++ b/usage_test.go
@@ -317,6 +317,7 @@ func TestUsageWithNestedSubcommands(t *testing.T) {
 	expectedUsage := "Usage: example child nested [--enable] OUTPUT"
 
 	expectedHelp := `
+this program does this and that
 Usage: example child nested [--enable] OUTPUT
 
 Positional arguments:
@@ -336,6 +337,7 @@ Global options:
 		Child   *struct {
 			Values []float64 `help:"Values"`
 			Nested *struct {
+				described
 				Enable bool
 				Output string `arg:"positional,required"`
 			} `arg:"subcommand:nested"`


### PR DESCRIPTION
A follow-up on https://github.com/alexflint/go-arg/pull/156 to address https://github.com/alexflint/go-arg/issues/139.

`writeHelpForSubcommand` checks whether the given subcommand implements the `Described` interface. If it does not, we fallback to the main command's description.

### Testing it
```go
package main
import "github.com/alexflint/go-arg"

func main() {
	arg.MustParse(new(rootCommand))
}

type rootCommand struct {
	One *firstCmd `arg:"subcommand:one"`
	Two *secondCmd `arg:"subcommand:two"`
}
func (*rootCommand) Description() string {
	return "main description"
}

type firstCmd struct {}
func (c *firstCmd) Description() string {
	return "subcommand description"
}

type secondCmd struct {}
```

```
± go run test/main.go --help | grep desc
main description
± go run test/main.go one --help | grep desc
subcommand description
± go run test/main.go two --help | grep desc
main description
```

### Limitation

Due to how the commands and args are tokenized, the invocation below describes the main command instead of the `one` subcommand. I am not sure whether that's desirable or not.
```
± go run test/main.go --help one | grep desc
main description
```