### PR TITLE
Fix int parsing for arg:"env" when environment variable value is empty

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -677,6 +677,42 @@ func TestEnvironmentVariable(t *testing.T) {
 	assert.Equal(t, "bar", args.Foo)
 }
 
+func TestEnvironmentVariableInt(t *testing.T) {
+	var args struct {
+		Foo int `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO=12"}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 12, args.Foo)
+}
+
+func TestEnvironmentVariableFloat32(t *testing.T) {
+	var args struct {
+		Foo float32 `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO=12.12"}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, float32(12.12), args.Foo)
+}
+
+func TestEnvironmentVariableFloat64(t *testing.T) {
+	var args struct {
+		Foo float64 `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO=12.12"}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 12.12, args.Foo)
+}
+
+func TestEnvironmentVariableBool(t *testing.T) {
+	var args struct {
+		Foo bool `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO=true"}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, true, args.Foo)
+}
+
 func TestEnvironmentVariableNotPresent(t *testing.T) {
 	var args struct {
 		NotPresent string `arg:"env"`
@@ -684,6 +720,42 @@ func TestEnvironmentVariableNotPresent(t *testing.T) {
 	_, err := parseWithEnv("", nil, &args)
 	require.NoError(t, err)
 	assert.Equal(t, "", args.NotPresent)
+}
+
+func TestEnvironmentVariableIntValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo int `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{`FOO=`}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 0, args.Foo)
+}
+
+func TestEnvironmentVariableFloat32ValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo float32 `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{`FOO=`}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, float32(0.0), args.Foo)
+}
+
+func TestEnvironmentVariableFloat64ValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo float64 `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{`FOO=`}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, args.Foo)
+}
+
+func TestEnvironmentVariableBoolValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo bool `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{`FOO=`}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, false, args.Foo)
 }
 
 func TestEnvironmentVariableOverrideName(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -677,6 +677,15 @@ func TestEnvironmentVariable(t *testing.T) {
 	assert.Equal(t, "bar", args.Foo)
 }
 
+func TestEnvironmentVariableStringPointer(t *testing.T) {
+	var args struct {
+		Foo *string `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO=bar"}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", *args.Foo)
+}
+
 func TestEnvironmentVariableInt(t *testing.T) {
 	var args struct {
 		Foo int `arg:"env"`
@@ -720,6 +729,69 @@ func TestEnvironmentVariableNotPresent(t *testing.T) {
 	_, err := parseWithEnv("", nil, &args)
 	require.NoError(t, err)
 	assert.Equal(t, "", args.NotPresent)
+}
+
+func TestEnvironmentVariableStringPointerNotPresent(t *testing.T) {
+	var args struct {
+		NotPresent *string `arg:"env"`
+	}
+	_, err := parseWithEnv("", nil, &args)
+	require.NoError(t, err)
+	assert.Equal(t, "", *args.NotPresent)
+}
+
+func TestEnvironmentVariableIntNotPresent(t *testing.T) {
+	var args struct {
+		NotPresent int `arg:"env"`
+	}
+	_, err := parseWithEnv("", nil, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 0, args.NotPresent)
+}
+
+func TestEnvironmentVariableFloat32NotPresent(t *testing.T) {
+	var args struct {
+		NotPresent float32 `arg:"env"`
+	}
+	_, err := parseWithEnv("", nil, &args)
+	require.NoError(t, err)
+	assert.Equal(t, float32(0.0), args.NotPresent)
+}
+
+func TestEnvironmentVariableFloat64NotPresent(t *testing.T) {
+	var args struct {
+		NotPresent float64 `arg:"env"`
+	}
+	_, err := parseWithEnv("", nil, &args)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, args.NotPresent)
+}
+
+func TestEnvironmentVariableBoolNotPresent(t *testing.T) {
+	var args struct {
+		NotPresent bool `arg:"env"`
+	}
+	_, err := parseWithEnv("", nil, &args)
+	require.NoError(t, err)
+	assert.Equal(t, false, args.NotPresent)
+}
+
+func TestEnvironmentVariableValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO="}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, "", args.Foo)
+}
+
+func TestEnvironmentVariableStringPointerValueNotPresent(t *testing.T) {
+	var args struct {
+		Foo *string `arg:"env"`
+	}
+	_, err := parseWithEnv("", []string{"FOO="}, &args)
+	require.NoError(t, err)
+	assert.Equal(t, "", *args.Foo)
 }
 
 func TestEnvironmentVariableIntValueNotPresent(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug in reference to #160 