### PR TITLE
Accept only argument as environment variable

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -508,16 +508,42 @@ func Example_allSupportedTypes() {
 
 func Example_envVarOnly() {
 	os.Args = split("./example")
-	_ = os.Setenv("NUM_WORKERS", "my_key")
+	_ = os.Setenv("AUTH_KEY", "my_key")
 
-	defer os.Unsetenv("NUM_WORKERS")
+	defer os.Unsetenv("AUTH_KEY")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:NUM_WORKERS"`
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
 	}
 
 	MustParse(&args)
 
 	fmt.Println(args.AuthKey)
 	// output: my_key
+}
+
+func Example_envVarOnlyShouldIgnoreFlag() {
+	os.Args = split("./example --=my_key")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+	}
+
+	err := Parse(&args)
+
+	fmt.Println(err)
+	// output: unknown argument --=my_key
+}
+
+func Example_envVarOnlyShouldIgnoreShortFlag() {
+	os.Args = split("./example -=my_key")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+	}
+
+	err := Parse(&args)
+
+	fmt.Println(err)
+	// output: unknown argument -=my_key
 }

--- a/example_test.go
+++ b/example_test.go
@@ -513,7 +513,7 @@ func Example_envVarOnly() {
 	defer os.Unsetenv("AUTH_KEY")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	MustParse(&args)
@@ -526,7 +526,7 @@ func Example_envVarOnlyShouldIgnoreFlag() {
 	os.Args = split("./example --=my_key")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	err := Parse(&args)
@@ -539,7 +539,7 @@ func Example_envVarOnlyShouldIgnoreShortFlag() {
 	os.Args = split("./example -=my_key")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	err := Parse(&args)

--- a/example_test.go
+++ b/example_test.go
@@ -505,3 +505,19 @@ func Example_allSupportedTypes() {
 
 	// output:
 }
+
+func Example_envVarOnly() {
+	os.Args = split("./example")
+	_ = os.Setenv("NUM_WORKERS", "my_key")
+
+	defer os.Unsetenv("NUM_WORKERS")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:NUM_WORKERS"`
+	}
+
+	MustParse(&args)
+
+	fmt.Println(args.AuthKey)
+	// output: my_key
+}

--- a/parse.go
+++ b/parse.go
@@ -312,6 +312,11 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			case strings.HasPrefix(key, "--"):
 				spec.long = key[2:]
 			case strings.HasPrefix(key, "-"):
+				if len(key) != 2 {
+					errs = append(errs, fmt.Sprintf("%s.%s: short arguments must be one character only",
+						t.Name(), field.Name))
+					return false
+				}
 				spec.short = key[1:]
 			case key == "required":
 				if hasDefault {

--- a/parse.go
+++ b/parse.go
@@ -312,11 +312,6 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			case strings.HasPrefix(key, "--"):
 				spec.long = key[2:]
 			case strings.HasPrefix(key, "-"):
-				if len(key) != 2 {
-					errs = append(errs, fmt.Sprintf("%s.%s: short arguments must be one character only",
-						t.Name(), field.Name))
-					return false
-				}
 				spec.short = key[1:]
 			case key == "required":
 				if hasDefault {

--- a/parse.go
+++ b/parse.go
@@ -559,7 +559,7 @@ func (p *Parser) process(args []string) error {
 		// lookup the spec for this option (note that the "specs" slice changes as
 		// we expand subcommands so it is better not to use a map)
 		spec := findOption(specs, opt)
-		if spec == nil {
+		if spec == nil || opt == "" {
 			return fmt.Errorf("unknown argument %s", arg)
 		}
 		wasPresent[spec] = true

--- a/usage.go
+++ b/usage.go
@@ -92,9 +92,10 @@ func (p *Parser) writeUsageForSubcommand(w io.Writer, cmd *command) {
 		ancestors = append(ancestors, ancestor.name)
 		ancestor = ancestor.parent
 	}
+	// Print environment only variables
 	for _, spec := range cmd.specs {
 		if spec.short == "" && spec.long == "" {
-			ancestors = append(ancestors, spec.env+"="+strings.ToLower(spec.env)+"_value")
+			ancestors = append(ancestors, "["+spec.env+"="+strings.ToLower(spec.env)+"_value"+"]")
 		}
 	}
 
@@ -291,7 +292,7 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 	}
 
 	// write the list of environment only variables
-	if len(shortOptions)+len(longOptions) > 0 || cmd.parent == nil {
+	if len(envOnlyOptions) > 0 {
 		fmt.Fprint(w, "\nEnvironment variables:\n")
 		for _, spec := range envOnlyOptions {
 			p.printEnvOnlyVar(w, spec)

--- a/usage_test.go
+++ b/usage_test.go
@@ -602,3 +602,32 @@ error: something went wrong
 	assert.Equal(t, expectedStdout[1:], b.String())
 	assert.Equal(t, -1, exitCode)
 }
+
+func TestFailEnvOnly(t *testing.T) {
+	expectedUsage := "Usage: AUTH_KEY=auth_key_value example [--arg ARG]"
+
+	expectedHelp := `
+Usage: AUTH_KEY=auth_key_value example [--arg ARG]
+
+Options:
+  --arg ARG, -a ARG [env: MY_ARG]
+  --help, -h             display this help and exit
+
+Environment variables:
+  AUTH_KEY
+`
+	var args struct {
+		ArgParam string `arg:"-a,--arg,env:MY_ARG"`
+		AuthKey  string `arg:"-,--,env:AUTH_KEY"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp[1:], help.String())
+
+	var usage bytes.Buffer
+	p.WriteUsage(&usage)
+	assert.Equal(t, expectedUsage, strings.TrimSpace(usage.String()))
+}

--- a/usage_test.go
+++ b/usage_test.go
@@ -514,14 +514,18 @@ Options:
 }
 
 func TestUsageWithEnvOptions(t *testing.T) {
-	expectedUsage := "Usage: example [-s SHORT]"
+	expectedUsage := "Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]"
 
 	expectedHelp := `
-Usage: example [-s SHORT]
+Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]
 
 Options:
   -s SHORT [env: SHORT]
   --help, -h             display this help and exit
+
+Environment variables:
+  ENVONLY
+  CUSTOM
 `
 	var args struct {
 		Short            string `arg:"--,-s,env"`
@@ -604,10 +608,10 @@ error: something went wrong
 }
 
 func TestFailEnvOnly(t *testing.T) {
-	expectedUsage := "Usage: AUTH_KEY=auth_key_value example [--arg ARG]"
+	expectedUsage := "Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]"
 
 	expectedHelp := `
-Usage: AUTH_KEY=auth_key_value example [--arg ARG]
+Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]
 
 Options:
   --arg ARG, -a ARG [env: MY_ARG]
@@ -618,7 +622,7 @@ Environment variables:
 `
 	var args struct {
 		ArgParam string `arg:"-a,--arg,env:MY_ARG"`
-		AuthKey  string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey  string `arg:"--,env:AUTH_KEY"`
 	}
 	p, err := NewParser(Config{Program: "example"}, &args)
 	assert.NoError(t, err)


### PR DESCRIPTION
Now ignores if the short argument is empty, so we can only accept the environment variable.

I notice that test: `TestInvalidShortFlag` breaks, but it seems this test was done thinking that it shouldn't support a short flag with more than one character. Thinks like this one: `-foo`... Not sure if I can remove this test

Closes #179 

