### PR TITLE
Implement MustParse on Parser

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -82,18 +82,7 @@ func MustParse(dest ...interface{}) *Parser {
 		return nil // just in case osExit was monkey-patched
 	}
 
-	err = p.Parse(flags())
-	switch {
-	case err == ErrHelp:
-		p.writeHelpForSubcommand(stdout, p.lastCmd)
-		osExit(0)
-	case err == ErrVersion:
-		fmt.Fprintln(stdout, p.version)
-		osExit(0)
-	case err != nil:
-		p.failWithSubcommand(err.Error(), p.lastCmd)
-	}
-
+	p.MustParse(flags())
 	return p
 }
 
@@ -447,6 +436,20 @@ func (p *Parser) Parse(args []string) error {
 		}
 	}
 	return err
+}
+
+func (p *Parser) MustParse(args []string) {
+	err := p.Parse(args)
+	switch {
+	case err == ErrHelp:
+		p.writeHelpForSubcommand(stdout, p.lastCmd)
+		osExit(0)
+	case err == ErrVersion:
+		fmt.Fprintln(stdout, p.version)
+		osExit(0)
+	case err != nil:
+		p.failWithSubcommand(err.Error(), p.lastCmd)
+	}
 }
 
 // process environment vars for the given arguments


### PR DESCRIPTION
This moves most of the body of the MustParse function into a MustParse method on a Parser. The MustParse function is now implemented by calling the MustParse method on the Parser it implicitly creates.

Closes: #194