### PR TITLE
Make usage and help output configurable

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"text/template"
 
 	scalar "github.com/alexflint/go-scalar"
 )
@@ -127,6 +128,8 @@ type Parser struct {
 
 	// the following field changes during processing of command line arguments
 	lastCmd *command
+
+	usageTemplate *template.Template
 }
 
 // Versioned is the interface that the destination struct should implement to
@@ -192,6 +195,13 @@ func NewParser(config Config, dests ...interface{}) (*Parser, error) {
 		cmd:    &command{name: name},
 		config: config,
 	}
+
+	// build the usage template
+	tmpl, err := template.New("usage").Parse(usageTemplate)
+	if err != nil {
+		return nil, err
+	}
+	p.usageTemplate = tmpl
 
 	// make a list of roots
 	for _, dest := range dests {


### PR DESCRIPTION
This is a first pass looking to gather feedback on solving #193, #163, #146 and hopefully also #139.

Essentially, this makes use of `text/template` to specify the output format. It introduces a `buildUsageForSubcommand` which uses a string builder to build up the usage string that's then interpolated into the Go template.

I haven't modified any of the tests and they still all pass, which at the very least suggest the behaviour is the same.

The idea is to then make the template settable through arg, like `func (arg) UsageTemplate() *template.Template {}`, and if no such template is provided then `p.usageTemplate` would use the `const usageTemplate`.

The code is a little rough right now, but it's the general direction I'm thinking of. Does this align with what you had in mind?