### PR TITLE
add strict subcommand parsing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/alexflint/go-scalar v1.1.0 h1:aaAouLLzI9TChcPXotr6gUhq+Scr8rl0P9P4PnltbhM=
-github.com/alexflint/go-scalar v1.1.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
 github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/parse.go
+++ b/parse.go
@@ -116,7 +116,7 @@ type Config struct {
 	// default values, including pointers to sub commands
 	IgnoreDefault bool
 
-	// IgnoreDefault intructs the library not to allow global commands after
+	// StrictSubcommands intructs the library not to allow global commands after
 	// subcommand
 	StrictSubcommands bool
 }

--- a/parse.go
+++ b/parse.go
@@ -115,6 +115,10 @@ type Config struct {
 	// IgnoreDefault instructs the library not to reset the variables to the
 	// default values, including pointers to sub commands
 	IgnoreDefault bool
+
+	// IgnoreDefault intructs the library not to allow global commands after
+	// subcommand
+	StrictSubcommands bool
 }
 
 // Parser represents a set of command line options with destination values
@@ -588,7 +592,12 @@ func (p *Parser) process(args []string) error {
 			}
 
 			// add the new options to the set of allowed options
-			specs = append(specs, subcmd.specs...)
+			if p.config.StrictSubcommands {
+				specs = make([]*spec, len(subcmd.specs))
+				copy(specs, subcmd.specs)
+			} else {
+				specs = append(specs, subcmd.specs...)
+			}
 
 			// capture environment vars for these new options
 			if !p.config.IgnoreEnv {


### PR DESCRIPTION
Add option to parser to disallow global flags after subcommand name

Sometimes it's helpful to have a more strict command ordering

Tests added