### PR TITLE
feat: support more env than terminal

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -39,9 +39,9 @@ func (p *Parser) FailSubcommand(msg string, subcommand ...string) error {
 
 // failWithSubcommand prints usage information for the given subcommand to stderr and exits with non-zero status
 func (p *Parser) failWithSubcommand(msg string, cmd *command) {
-	p.writeUsageForSubcommand(stderr, cmd)
-	fmt.Fprintln(stderr, "error:", msg)
-	osExit(-1)
+	p.writeUsageForSubcommand(p.stderr, cmd)
+	fmt.Fprintln(p.stderr, "error:", msg)
+	p.osExit(-1)
 }
 
 // WriteUsage writes usage information to the given writer


### PR DESCRIPTION
go-arg is a great job for terminal use. And I need to support parameter parsing in web scenarios, so I extended some of the code. Terminal is supported by default. When need to support other scenarios, users can customize standard input and output.