### PR TITLE
clean up customizable stdout, stderr, and exit in parser config

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -162,8 +162,7 @@ func Example_helpText() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -195,8 +194,7 @@ func Example_helpPlaceholder() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -236,8 +234,7 @@ func Example_helpTextWithSubcommand() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -274,8 +271,7 @@ func Example_helpTextWhenUsingSubcommand() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -311,10 +307,9 @@ func Example_writeHelpForSubcommand() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	exit := func(int) {}
 
-	p, err := NewParser(Config{}, &args)
+	p, err := NewParser(Config{Exit: exit}, &args)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -360,10 +355,9 @@ func Example_writeHelpForSubcommandNested() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stdout = os.Stdout
+	exit := func(int) {}
 
-	p, err := NewParser(Config{}, &args)
+	p, err := NewParser(Config{Exit: exit}, &args)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -397,8 +391,7 @@ func Example_errorText() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stderr = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -421,8 +414,7 @@ func Example_errorTextForSubcommand() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stderr = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 
@@ -457,8 +449,7 @@ func Example_subcommand() {
 	}
 
 	// This is only necessary when running inside golang's runnable example harness
-	osExit = func(int) {}
-	stderr = os.Stdout
+	mustParseExit = func(int) {}
 
 	MustParse(&args)
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -885,26 +885,18 @@ func TestParserMustParse(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			originalExit := osExit
-			originalStdout := stdout
-			defer func() {
-				osExit = originalExit
-				stdout = originalStdout
-			}()
+			var exitCode int
+			var stdout bytes.Buffer
+			exit := func(code int) { exitCode = code }
 
-			var exitCode *int
-			osExit = func(code int) { exitCode = &code }
-			var b bytes.Buffer
-			stdout = &b
-
-			p, err := NewParser(Config{}, &tt.args)
+			p, err := NewParser(Config{Exit: exit, Out: &stdout}, &tt.args)
 			require.NoError(t, err)
 			assert.NotNil(t, p)
 
 			p.MustParse(tt.cmdLine)
 			assert.NotNil(t, exitCode)
-			assert.Equal(t, tt.code, *exitCode)
-			assert.Contains(t, b.String(), tt.output)
+			assert.Equal(t, tt.code, exitCode)
+			assert.Contains(t, stdout.String(), tt.output)
 		})
 	}
 }
@@ -1484,70 +1476,53 @@ func TestUnexportedFieldsSkipped(t *testing.T) {
 }
 
 func TestMustParseInvalidParser(t *testing.T) {
-	originalExit := osExit
-	originalStdout := stdout
-	defer func() {
-		osExit = originalExit
-		stdout = originalStdout
-	}()
-
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
-	stdout = &bytes.Buffer{}
+	var stdout bytes.Buffer
+	exit := func(code int) { exitCode = code }
 
 	var args struct {
 		CannotParse struct{}
 	}
-	parser := MustParse(&args)
+	parser := mustParse(Config{Out: &stdout, Exit: exit}, &args)
 	assert.Nil(t, parser)
 	assert.Equal(t, -1, exitCode)
 }
 
 func TestMustParsePrintsHelp(t *testing.T) {
-	originalExit := osExit
-	originalStdout := stdout
 	originalArgs := os.Args
 	defer func() {
-		osExit = originalExit
-		stdout = originalStdout
 		os.Args = originalArgs
 	}()
 
-	var exitCode *int
-	osExit = func(code int) { exitCode = &code }
 	os.Args = []string{"someprogram", "--help"}
-	stdout = &bytes.Buffer{}
+
+	var exitCode int
+	var stdout bytes.Buffer
+	exit := func(code int) { exitCode = code }
 
 	var args struct{}
-	parser := MustParse(&args)
+	parser := mustParse(Config{Out: &stdout, Exit: exit}, &args)
 	assert.NotNil(t, parser)
-	require.NotNil(t, exitCode)
-	assert.Equal(t, 0, *exitCode)
+	assert.Equal(t, 0, exitCode)
 }
 
 func TestMustParsePrintsVersion(t *testing.T) {
-	originalExit := osExit
-	originalStdout := stdout
 	originalArgs := os.Args
 	defer func() {
-		osExit = originalExit
-		stdout = originalStdout
 		os.Args = originalArgs
 	}()
 
-	var exitCode *int
-	osExit = func(code int) { exitCode = &code }
+	var exitCode int
+	var stdout bytes.Buffer
+	exit := func(code int) { exitCode = code }
+
 	os.Args = []string{"someprogram", "--version"}
 
-	var b bytes.Buffer
-	stdout = &b
-
 	var args versioned
-	parser := MustParse(&args)
+	parser := mustParse(Config{Out: &stdout, Exit: exit}, &args)
 	require.NotNil(t, parser)
-	require.NotNil(t, exitCode)
-	assert.Equal(t, 0, *exitCode)
-	assert.Equal(t, "example 3.2.1\n", b.String())
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "example 3.2.1\n", stdout.String())
 }
 
 type mapWithUnmarshalText struct {

--- a/usage.go
+++ b/usage.go
@@ -3,19 +3,11 @@ package arg
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 )
 
 // the width of the left column
 const colWidth = 25
-
-// to allow monkey patching in tests
-var (
-	stdout io.Writer = os.Stdout
-	stderr io.Writer = os.Stderr
-	osExit           = os.Exit
-)
 
 // Fail prints usage information to stderr and exits with non-zero status
 func (p *Parser) Fail(msg string) {
@@ -39,9 +31,9 @@ func (p *Parser) FailSubcommand(msg string, subcommand ...string) error {
 
 // failWithSubcommand prints usage information for the given subcommand to stderr and exits with non-zero status
 func (p *Parser) failWithSubcommand(msg string, cmd *command) {
-	p.writeUsageForSubcommand(p.stderr, cmd)
-	fmt.Fprintln(p.stderr, "error:", msg)
-	p.osExit(-1)
+	p.writeUsageForSubcommand(p.config.Out, cmd)
+	fmt.Fprintln(p.config.Out, "error:", msg)
+	p.config.Exit(-1)
 }
 
 // WriteUsage writes usage information to the given writer

--- a/usage_test.go
+++ b/usage_test.go
@@ -572,18 +572,9 @@ Options:
 }
 
 func TestFail(t *testing.T) {
-	originalStderr := stderr
-	originalExit := osExit
-	defer func() {
-		stderr = originalStderr
-		osExit = originalExit
-	}()
-
-	var b bytes.Buffer
-	stderr = &b
-
+	var stdout bytes.Buffer
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
+	exit := func(code int) { exitCode = code }
 
 	expectedStdout := `
 Usage: example [--foo FOO]
@@ -593,27 +584,18 @@ error: something went wrong
 	var args struct {
 		Foo int
 	}
-	p, err := NewParser(Config{Program: "example"}, &args)
+	p, err := NewParser(Config{Program: "example", Exit: exit, Out: &stdout}, &args)
 	require.NoError(t, err)
 	p.Fail("something went wrong")
 
-	assert.Equal(t, expectedStdout[1:], b.String())
+	assert.Equal(t, expectedStdout[1:], stdout.String())
 	assert.Equal(t, -1, exitCode)
 }
 
 func TestFailSubcommand(t *testing.T) {
-	originalStderr := stderr
-	originalExit := osExit
-	defer func() {
-		stderr = originalStderr
-		osExit = originalExit
-	}()
-
-	var b bytes.Buffer
-	stderr = &b
-
+	var stdout bytes.Buffer
 	var exitCode int
-	osExit = func(code int) { exitCode = code }
+	exit := func(code int) { exitCode = code }
 
 	expectedStdout := `
 Usage: example sub
@@ -623,13 +605,13 @@ error: something went wrong
 	var args struct {
 		Sub *struct{} `arg:"subcommand"`
 	}
-	p, err := NewParser(Config{Program: "example"}, &args)
+	p, err := NewParser(Config{Program: "example", Exit: exit, Out: &stdout}, &args)
 	require.NoError(t, err)
 
 	err = p.FailSubcommand("something went wrong", "sub")
 	require.NoError(t, err)
 
-	assert.Equal(t, expectedStdout[1:], b.String())
+	assert.Equal(t, expectedStdout[1:], stdout.String())
 	assert.Equal(t, -1, exitCode)
 }
 


### PR DESCRIPTION
Following very helpful pull request #210, here I clean up a few different ways that it was previously possible to customize the exit function and output writer used by MustParse and friends.

Note @cabuda this changes the interface in your pr a bit. Now the config struct just contains fields "Out" and "Exit".