### PR TITLE
Support for parameters which can only be passed via env

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -496,3 +496,19 @@ func Example_allSupportedTypes() {
 
 	// output:
 }
+
+func Example_envVarOnly() {
+	os.Args = split("./example")
+	_ = os.Setenv("NUM_WORKERS", "my_key")
+
+	defer os.Unsetenv("NUM_WORKERS")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:NUM_WORKERS"`
+	}
+
+	MustParse(&args)
+
+	fmt.Println(args.AuthKey)
+	// output: my_key
+}

--- a/example_test.go
+++ b/example_test.go
@@ -504,7 +504,7 @@ func Example_envVarOnly() {
 	defer os.Unsetenv("AUTH_KEY")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	MustParse(&args)
@@ -517,7 +517,7 @@ func Example_envVarOnlyShouldIgnoreFlag() {
 	os.Args = split("./example --=my_key")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	err := Parse(&args)
@@ -530,7 +530,7 @@ func Example_envVarOnlyShouldIgnoreShortFlag() {
 	os.Args = split("./example -=my_key")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey string `arg:"--,env:AUTH_KEY"`
 	}
 
 	err := Parse(&args)

--- a/example_test.go
+++ b/example_test.go
@@ -499,16 +499,42 @@ func Example_allSupportedTypes() {
 
 func Example_envVarOnly() {
 	os.Args = split("./example")
-	_ = os.Setenv("NUM_WORKERS", "my_key")
+	_ = os.Setenv("AUTH_KEY", "my_key")
 
-	defer os.Unsetenv("NUM_WORKERS")
+	defer os.Unsetenv("AUTH_KEY")
 
 	var args struct {
-		AuthKey string `arg:"-,--,env:NUM_WORKERS"`
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
 	}
 
 	MustParse(&args)
 
 	fmt.Println(args.AuthKey)
 	// output: my_key
+}
+
+func Example_envVarOnlyShouldIgnoreFlag() {
+	os.Args = split("./example --=my_key")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+	}
+
+	err := Parse(&args)
+
+	fmt.Println(err)
+	// output: unknown argument --=my_key
+}
+
+func Example_envVarOnlyShouldIgnoreShortFlag() {
+	os.Args = split("./example -=my_key")
+
+	var args struct {
+		AuthKey string `arg:"-,--,env:AUTH_KEY"`
+	}
+
+	err := Parse(&args)
+
+	fmt.Println(err)
+	// output: unknown argument -=my_key
 }

--- a/parse.go
+++ b/parse.go
@@ -656,7 +656,7 @@ func (p *Parser) process(args []string) error {
 		// lookup the spec for this option (note that the "specs" slice changes as
 		// we expand subcommands so it is better not to use a map)
 		spec := findOption(specs, opt)
-		if spec == nil {
+		if spec == nil || opt == "" {
 			return fmt.Errorf("unknown argument %s", arg)
 		}
 		wasPresent[spec] = true

--- a/parse.go
+++ b/parse.go
@@ -54,10 +54,9 @@ type spec struct {
 	separate      bool                // if true, each slice and map entry will have its own --flag
 	help          string              // the help text for this option
 	env           string              // the name of the environment variable for this option, or empty for none
-	envOnly       bool
-	defaultValue  reflect.Value // default value for this option
-	defaultString string        // default value for this option, in string form to be displayed in help text
-	placeholder   string        // name of the data in help
+	defaultValue  reflect.Value       // default value for this option
+	defaultString string              // default value for this option, in string form to be displayed in help text
+	placeholder   string              // name of the data in help
 }
 
 // command represents a named subcommand, or the top-level command
@@ -344,9 +343,8 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 
 		// Look at the tag
 		var isSubcommand bool // tracks whether this field is a subcommand
-		kvPairs := strings.Split(tag, ",")
 
-		for _, key := range kvPairs {
+		for _, key := range strings.Split(tag, ",") {
 			if key == "" {
 				continue
 			}
@@ -416,16 +414,6 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			spec.placeholder = strings.ToUpper(spec.long)
 		} else {
 			spec.placeholder = strings.ToUpper(spec.field.Name)
-		}
-
-		noFormSpecs := emptyLongAndShort(kvPairs)
-
-		if spec.env == "" && noFormSpecs {
-			errs = append(errs, fmt.Sprintf("%s.%s: short arguments must be one character only",
-				t.Name(), field.Name))
-			return false
-		} else if spec.env != "" && noFormSpecs {
-			spec.envOnly = true
 		}
 
 		// if this is a subcommand then we've done everything we need to do
@@ -763,7 +751,7 @@ func (p *Parser) process(args []string) error {
 		}
 
 		if spec.required {
-			if spec.envOnly {
+			if spec.short == "" && spec.long == "" {
 				msg := fmt.Sprintf("environment variable %s is required", spec.env)
 				return errors.New(msg)
 			}
@@ -805,22 +793,6 @@ func nextIsNumeric(t reflect.Type, s string) bool {
 // isFlag returns true if a token is a flag such as "-v" or "--user" but not "-" or "--"
 func isFlag(s string) bool {
 	return strings.HasPrefix(s, "-") && strings.TrimLeft(s, "-") != ""
-}
-
-func emptyLongAndShort(kv []string) bool {
-	var noShort, noLong bool
-	for _, key := range kv {
-		if key == "-" {
-			noShort = true
-		}
-
-		if key == "--" {
-			noLong = true
-		}
-	}
-
-	return noShort && noLong
-
 }
 
 // val returns a reflect.Value corresponding to the current value for the

--- a/parse.go
+++ b/parse.go
@@ -360,11 +360,6 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			case strings.HasPrefix(key, "--"):
 				spec.long = key[2:]
 			case strings.HasPrefix(key, "-"):
-				if len(key) != 2 {
-					errs = append(errs, fmt.Sprintf("%s.%s: short arguments must be one character only",
-						t.Name(), field.Name))
-					return false
-				}
 				spec.short = key[1:]
 			case key == "required":
 				spec.required = true

--- a/parse.go
+++ b/parse.go
@@ -360,6 +360,11 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			case strings.HasPrefix(key, "--"):
 				spec.long = key[2:]
 			case strings.HasPrefix(key, "-"):
+				if len(key) != 2 {
+					errs = append(errs, fmt.Sprintf("%s.%s: short arguments must be one character only",
+						t.Name(), field.Name))
+					return false
+				}
 				spec.short = key[1:]
 			case key == "required":
 				spec.required = true

--- a/parse_test.go
+++ b/parse_test.go
@@ -227,6 +227,14 @@ func TestRequiredWithEnv(t *testing.T) {
 	require.Error(t, err, "--foo is required (or environment variable FOO)")
 }
 
+func TestRequiredWithEnvOnly(t *testing.T) {
+	var args struct {
+		Foo string `arg:"required,--,-,env:FOO"`
+	}
+	_, err := parseWithEnv("", []string{}, &args)
+	require.Error(t, err, "environment variable FOO is required")
+}
+
 func TestShortFlag(t *testing.T) {
 	var args struct {
 		Foo string `arg:"-f"`
@@ -843,6 +851,24 @@ func TestDefaultValuesIgnored(t *testing.T) {
 	err = p.Parse(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "", args.Foo)
+}
+
+func TestRequiredEnvironmentOnlyVariableIsMissing(t *testing.T) {
+	var args struct {
+		Foo string `arg:"required,--,env:FOO"`
+	}
+
+	_, err := parseWithEnv("", []string{""}, &args)
+	assert.Error(t, err)
+}
+
+func TestOptionalEnvironmentOnlyVariable(t *testing.T) {
+	var args struct {
+		Foo string `arg:"env:FOO"`
+	}
+
+	_, err := parseWithEnv("", []string{}, &args)
+	assert.NoError(t, err)
 }
 
 func TestEnvironmentVariableInSubcommandIgnored(t *testing.T) {

--- a/usage.go
+++ b/usage.go
@@ -312,7 +312,18 @@ func (p *Parser) printOption(w io.Writer, spec *spec) {
 }
 
 func (p *Parser) printEnvOnlyVar(w io.Writer, spec *spec) {
-	printTwoCols(w, spec.env, "", "", "")
+	ways := make([]string, 0, 2)
+	if spec.required {
+		ways = append(ways, "Required.")
+	} else {
+		ways = append(ways, "Optional.")
+	}
+
+	if spec.help != "" {
+		ways = append(ways, spec.help)
+	}
+
+	printTwoCols(w, spec.env, strings.Join(ways, " "), spec.defaultString, "")
 }
 
 // lookupCommand finds a subcommand based on a sequence of subcommand names. The

--- a/usage.go
+++ b/usage.go
@@ -84,6 +84,11 @@ func (p *Parser) writeUsageForSubcommand(w io.Writer, cmd *command) {
 		ancestors = append(ancestors, ancestor.name)
 		ancestor = ancestor.parent
 	}
+	for _, spec := range cmd.specs {
+		if spec.short == "" && spec.long == "" {
+			ancestors = append(ancestors, spec.env+"="+strings.ToLower(spec.env)+"_value")
+		}
+	}
 
 	// print the beginning of the usage string
 	fmt.Fprint(w, "Usage:")
@@ -208,7 +213,7 @@ func (p *Parser) WriteHelpForSubcommand(w io.Writer, subcommand ...string) error
 
 // writeHelp writes the usage string for the given subcommand
 func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
-	var positionals, longOptions, shortOptions []*spec
+	var positionals, longOptions, shortOptions, envOnlyOptions []*spec
 	for _, spec := range cmd.specs {
 		switch {
 		case spec.positional:
@@ -217,6 +222,8 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 			longOptions = append(longOptions, spec)
 		case spec.short != "":
 			shortOptions = append(shortOptions, spec)
+		case spec.short == "" && spec.long == "":
+			envOnlyOptions = append(envOnlyOptions, spec)
 		}
 	}
 
@@ -275,6 +282,14 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 		})
 	}
 
+	// write the list of environment only variables
+	if len(shortOptions)+len(longOptions) > 0 || cmd.parent == nil {
+		fmt.Fprint(w, "\nEnvironment variables:\n")
+		for _, spec := range envOnlyOptions {
+			p.printEnvOnlyVar(w, spec)
+		}
+	}
+
 	// write the list of subcommands
 	if len(cmd.subcommands) > 0 {
 		fmt.Fprint(w, "\nCommands:\n")
@@ -299,6 +314,10 @@ func (p *Parser) printOption(w io.Writer, spec *spec) {
 	if len(ways) > 0 {
 		printTwoCols(w, strings.Join(ways, ", "), spec.help, spec.defaultString, spec.env)
 	}
+}
+
+func (p *Parser) printEnvOnlyVar(w io.Writer, spec *spec) {
+	printTwoCols(w, spec.env, "", "", "")
 }
 
 // lookupCommand finds a subcommand based on a sequence of subcommand names. The

--- a/usage.go
+++ b/usage.go
@@ -84,9 +84,10 @@ func (p *Parser) writeUsageForSubcommand(w io.Writer, cmd *command) {
 		ancestors = append(ancestors, ancestor.name)
 		ancestor = ancestor.parent
 	}
+	// Print environment only variables
 	for _, spec := range cmd.specs {
 		if spec.short == "" && spec.long == "" {
-			ancestors = append(ancestors, spec.env+"="+strings.ToLower(spec.env)+"_value")
+			ancestors = append(ancestors, "["+spec.env+"="+strings.ToLower(spec.env)+"_value"+"]")
 		}
 	}
 
@@ -283,7 +284,7 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 	}
 
 	// write the list of environment only variables
-	if len(shortOptions)+len(longOptions) > 0 || cmd.parent == nil {
+	if len(envOnlyOptions) > 0 {
 		fmt.Fprint(w, "\nEnvironment variables:\n")
 		for _, spec := range envOnlyOptions {
 			p.printEnvOnlyVar(w, spec)

--- a/usage.go
+++ b/usage.go
@@ -84,12 +84,6 @@ func (p *Parser) writeUsageForSubcommand(w io.Writer, cmd *command) {
 		ancestors = append(ancestors, ancestor.name)
 		ancestor = ancestor.parent
 	}
-	// Print environment only variables
-	for _, spec := range cmd.specs {
-		if spec.short == "" && spec.long == "" {
-			ancestors = append(ancestors, "["+spec.env+"="+strings.ToLower(spec.env)+"_value"+"]")
-		}
-	}
 
 	// print the beginning of the usage string
 	fmt.Fprint(w, "Usage:")

--- a/usage_test.go
+++ b/usage_test.go
@@ -544,14 +544,18 @@ Options:
 }
 
 func TestUsageWithEnvOptions(t *testing.T) {
-	expectedUsage := "Usage: example [-s SHORT]"
+	expectedUsage := "Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]"
 
 	expectedHelp := `
-Usage: example [-s SHORT]
+Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]
 
 Options:
   -s SHORT [env: SHORT]
   --help, -h             display this help and exit
+
+Environment variables:
+  ENVONLY
+  CUSTOM
 `
 	var args struct {
 		Short            string `arg:"--,-s,env"`
@@ -648,10 +652,10 @@ Options:
 }
 
 func TestFailEnvOnly(t *testing.T) {
-	expectedUsage := "Usage: AUTH_KEY=auth_key_value example [--arg ARG]"
+	expectedUsage := "Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]"
 
 	expectedHelp := `
-Usage: AUTH_KEY=auth_key_value example [--arg ARG]
+Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]
 
 Options:
   --arg ARG, -a ARG [env: MY_ARG]
@@ -662,7 +666,7 @@ Environment variables:
 `
 	var args struct {
 		ArgParam string `arg:"-a,--arg,env:MY_ARG"`
-		AuthKey  string `arg:"-,--,env:AUTH_KEY"`
+		AuthKey  string `arg:"--,env:AUTH_KEY"`
 	}
 	p, err := NewParser(Config{Program: "example"}, &args)
 	assert.NoError(t, err)

--- a/usage_test.go
+++ b/usage_test.go
@@ -544,10 +544,10 @@ Options:
 }
 
 func TestUsageWithEnvOptions(t *testing.T) {
-	expectedUsage := "Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]"
+	expectedUsage := "Usage: example [-s SHORT]"
 
 	expectedHelp := `
-Usage: [CUSTOM=custom_value] [ENVONLY=envonly_value] example [-s SHORT]
+Usage: example [-s SHORT]
 
 Options:
   -s SHORT [env: SHORT]
@@ -652,10 +652,10 @@ Options:
 }
 
 func TestFailEnvOnly(t *testing.T) {
-	expectedUsage := "Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]"
+	expectedUsage := "Usage: example [--arg ARG]"
 
 	expectedHelp := `
-Usage: [AUTH_KEY=auth_key_value] example [--arg ARG]
+Usage: example [--arg ARG]
 
 Options:
   --arg ARG, -a ARG [env: MY_ARG]

--- a/usage_test.go
+++ b/usage_test.go
@@ -646,3 +646,32 @@ Options:
 	p.WriteHelp(&help)
 	assert.Equal(t, expectedHelp[1:], help.String())
 }
+
+func TestFailEnvOnly(t *testing.T) {
+	expectedUsage := "Usage: AUTH_KEY=auth_key_value example [--arg ARG]"
+
+	expectedHelp := `
+Usage: AUTH_KEY=auth_key_value example [--arg ARG]
+
+Options:
+  --arg ARG, -a ARG [env: MY_ARG]
+  --help, -h             display this help and exit
+
+Environment variables:
+  AUTH_KEY
+`
+	var args struct {
+		ArgParam string `arg:"-a,--arg,env:MY_ARG"`
+		AuthKey  string `arg:"-,--,env:AUTH_KEY"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	assert.NoError(t, err)
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp[1:], help.String())
+
+	var usage bytes.Buffer
+	p.WriteUsage(&usage)
+	assert.Equal(t, expectedUsage, strings.TrimSpace(usage.String()))
+}


### PR DESCRIPTION
Args from CLI can be disabled by "nulling" them using dashes without a value. 
- Closes #179 
- Continuation of #182 (@padilo) 
```golang
	var args struct {
		ApiKey   string     `arg:"required,-,--,env:API_KEY" help:"Only via env-var for security reasons"`
		Trace      bool     `arg:"--,env" help:"Record low-level trace"`
	}
```

```bash
Usage: example [--arg ARG]

Options:
  --arg ARG, -a ARG [env: MY_ARG]
  --help, -h             display this help and exit

Environment variables:
  API_KEY                 Required. Only via env-var for security reasons
  TRACE                   Optional. Record low-level trace
```