### PR TITLE
Fix usage writing when using custom version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ $ ./example --version
 someprogram 4.3.0
 ```
 
+> **Note**
+> If a `--version` flag is defined in `args` or any subcommand, it overrides the built-in versioning.
+
 ### Overriding option names
 
 ```go

--- a/usage.go
+++ b/usage.go
@@ -48,18 +48,36 @@ func (p *Parser) WriteUsageForSubcommand(w io.Writer, subcommand ...string) erro
 	}
 
 	var positionals, longOptions, shortOptions []*spec
+	var hasVersionOption bool
 	for _, spec := range cmd.specs {
 		switch {
 		case spec.positional:
 			positionals = append(positionals, spec)
 		case spec.long != "":
 			longOptions = append(longOptions, spec)
+			if spec.long == "version" {
+				hasVersionOption = true
+			}
 		case spec.short != "":
 			shortOptions = append(shortOptions, spec)
 		}
 	}
 
-	if p.version != "" {
+	// make a list of ancestor commands so that we print with full context
+	// also determine if any ancestor has a version option spec
+	var ancestors []string
+	ancestor := cmd
+	for ancestor != nil {
+		for _, spec := range ancestor.specs {
+			if spec.long == "version" {
+				hasVersionOption = true
+			}
+		}
+		ancestors = append(ancestors, ancestor.name)
+		ancestor = ancestor.parent
+	}
+
+	if !hasVersionOption && p.version != "" {
 		fmt.Fprintln(w, p.version)
 	}
 


### PR DESCRIPTION
Hi @alexflint , this is a small follow-up to PR #223 :)

I realized that I forgot to update the write usage function, and it was still printing the output of `Version()` even if a custom `--version` flag spec is present in the arguments. This is now also fixed and I added more unit tests for help/usage writing.

I also took the opportunity to improve a bit the way version flag specs are scanned for both usage and help writing.

I belive that this PR now fully addresses issue #171 because, when using a custom `--version` flag, the builtin version string (if any) is not printed anymore in usage and errors.

Fixes #171 