### PR TITLE
Display subcommand-relevant description for --help

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -223,9 +223,12 @@ func (p *Parser) writeHelpForSubcommand(w io.Writer, cmd *command) {
 		}
 	}
 
-	if p.description != "" {
+	if cmd.help != "" {
+		fmt.Fprintln(w, cmd.help)
+	} else if p.description != "" {
 		fmt.Fprintln(w, p.description)
 	}
+	
 	p.writeUsageForSubcommand(w, cmd)
 
 	// write the list of positionals

--- a/usage_test.go
+++ b/usage_test.go
@@ -415,6 +415,37 @@ Options:
 	assert.Equal(t, expectedUsage, usage.String())
 }
 
+func TestHelpWithSubcommandWithHelpText(t *testing.T) {
+	expectedHelp := `
+Description of what this subcommand does
+Usage: example child [--values VALUES]
+
+Options:
+  --values VALUES        Values
+
+Global options:
+  --verbose, -v          verbosity level
+  --help, -h             display this help and exit
+`
+
+	var args struct {
+		Verbose bool `arg:"-v" help:"verbosity level"`
+		Child   *struct {
+			Values []float64 `help:"Values"`
+		} `arg:"subcommand:child" help:"Description of what this subcommand does"`
+	}
+
+	os.Args[0] = "example"
+	p, err := NewParser(Config{}, &args)
+	require.NoError(t, err)
+
+	_ = p.Parse([]string{"child"})
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp[1:], help.String())
+}
+
 func TestUsageWithNestedSubcommands(t *testing.T) {
 	expectedUsage := "Usage: example child nested [--enable] OUTPUT"
 


### PR DESCRIPTION
Resolves #214
When subcommands have a relevant 'help' attribute, that help description is displayed when running with `--help`
This also replaces the global description if it exists