### PR TITLE
add an example for environment vars with arg names

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ $ WORKERS='1,99' ./example
 Workers: [1 99]
 ```
 
+You can also have an environment variable that doesn't match the arg name:
+
+```go
+var args struct {
+	Workers int `arg:"--count,env:NUM_WORKERS"`
+}
+arg.MustParse(&args)
+fmt.Println("Workers:", args.Workers)
+```
+
+```
+$ NUM_WORKERS=6 ./example
+Workers: 6
+$ NUM_WORKERS=6 ./example --count 4
+Workers: 4
+```
+
 ### Usage strings
 ```go
 var args struct {


### PR DESCRIPTION
If you want to specify both of these, and if they should have different
names, then this shows you how it can be done.