### PR TITLE
Handle explicit empty placeholders

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -56,7 +56,7 @@ type spec struct {
 	env           string              // the name of the environment variable for this option, or empty for none
 	defaultValue  reflect.Value       // default value for this option
 	defaultString string              // default value for this option, in string form to be displayed in help text
-	placeholder   string              // name of the data in help
+	placeholder   string              // placeholder string in help
 }
 
 // command represents a named subcommand, or the top-level command
@@ -341,9 +341,8 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			spec.help = help
 		}
 
-		// Look at the tag
-		var isSubcommand bool // tracks whether this field is a subcommand
-
+		// process each comma-separated part of the tag
+		var isSubcommand bool
 		for _, key := range strings.Split(tag, ",") {
 			if key == "" {
 				continue
@@ -407,6 +406,7 @@ func cmdFromStruct(name string, dest path, t reflect.Type) (*command, error) {
 			}
 		}
 
+		// placeholder is the string used in the help text like this: "--somearg PLACEHOLDER"
 		placeholder, hasPlaceholder := field.Tag.Lookup("placeholder")
 		if hasPlaceholder {
 			spec.placeholder = placeholder

--- a/usage.go
+++ b/usage.go
@@ -356,7 +356,10 @@ func (p *Parser) lookupCommand(path ...string) (*command, error) {
 }
 
 func synopsis(spec *spec, form string) string {
-	if spec.cardinality == zero {
+	// if the user omits the placeholder tag then we pick one automatically,
+	// but if the user explicitly specifies an empty placeholder then we
+	// leave out the placeholder in the help message
+	if spec.cardinality == zero || spec.placeholder == "" {
 		return form
 	}
 	return form + " " + spec.placeholder

--- a/usage_test.go
+++ b/usage_test.go
@@ -522,6 +522,35 @@ Options:
 	assert.Equal(t, expectedUsage, strings.TrimSpace(usage.String()))
 }
 
+func TestUsageWithEmptyPlaceholder(t *testing.T) {
+	expectedUsage := "Usage: example [-a] [--b] [--c]"
+
+	expectedHelp := `
+Usage: example [-a] [--b] [--c]
+
+Options:
+  -a                     some help for a
+  --b                    some help for b
+  --c, -c                some help for c
+  --help, -h             display this help and exit
+`
+	var args struct {
+		ShortOnly string `arg:"-a,--" placeholder:"" help:"some help for a"`
+		LongOnly  string `arg:"--b" placeholder:"" help:"some help for b"`
+		Both      string `arg:"-c,--c" placeholder:"" help:"some help for c"`
+	}
+	p, err := NewParser(Config{Program: "example"}, &args)
+	require.NoError(t, err)
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp[1:], help.String())
+
+	var usage bytes.Buffer
+	p.WriteUsage(&usage)
+	assert.Equal(t, expectedUsage, strings.TrimSpace(usage.String()))
+}
+
 func TestUsageWithShortFirst(t *testing.T) {
 	expectedUsage := "Usage: example [-c CAT] [--dog DOG]"
 


### PR DESCRIPTION
When the user explicitly sets the placeholder to empty, we change the usage text so that there aren't extraneous spaces:

```
var args struct {
    Something `arg:"-s" placeholder:"" help:"some help for something"`
}
```

```
...
Options:
  -s, --something    some help for something
...
```

Previous this would have printed usage text with some extraneous spaces: `-s , --something`

Closes #241 