### PR TITLE
Fix crash on errors in package-level `MustParse`

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -163,6 +163,7 @@ func Example_helpText() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -195,6 +196,7 @@ func Example_helpPlaceholder() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -235,6 +237,7 @@ func Example_helpTextWithSubcommand() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -272,6 +275,7 @@ func Example_helpTextWhenUsingSubcommand() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -392,6 +396,7 @@ func Example_errorText() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -415,6 +420,7 @@ func Example_errorTextForSubcommand() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 
@@ -450,6 +456,7 @@ func Example_subcommand() {
 
 	// This is only necessary when running inside golang's runnable example harness
 	mustParseExit = func(int) {}
+	mustParseOut = os.Stdout
 
 	MustParse(&args)
 

--- a/parse.go
+++ b/parse.go
@@ -76,12 +76,13 @@ var ErrHelp = errors.New("help requested by user")
 // ErrVersion indicates that the builtin --version was provided
 var ErrVersion = errors.New("version requested by user")
 
-// for monkey patching in example code
+// for monkey patching in example and test code
 var mustParseExit = os.Exit
+var mustParseOut io.Writer = os.Stdout
 
 // MustParse processes command line arguments and exits upon failure
 func MustParse(dest ...interface{}) *Parser {
-	return mustParse(Config{Exit: mustParseExit}, dest...)
+	return mustParse(Config{Exit: mustParseExit, Out: mustParseOut}, dest...)
 }
 
 // mustParse is a helper that facilitates testing

--- a/parse_test.go
+++ b/parse_test.go
@@ -692,6 +692,21 @@ func TestMustParse(t *testing.T) {
 	assert.NotNil(t, parser)
 }
 
+func TestMustParseError(t *testing.T) {
+	var args struct {
+		Foo []string `default:""`
+	}
+	var exitCode int
+	var stdout bytes.Buffer
+	mustParseExit = func(code int) { exitCode = code }
+	mustParseOut = &stdout
+	os.Args = []string{"example"}
+	parser := MustParse(&args)
+	assert.Nil(t, parser)
+	assert.Equal(t, -1, exitCode)
+	assert.Contains(t, stdout.String(), "default values are not supported for slice or map fields")
+}
+
 func TestEnvironmentVariable(t *testing.T) {
 	var args struct {
 		Foo string `arg:"env"`


### PR DESCRIPTION
This simple PR adds a test case for the package-level `MustParse` for invalid structs and fixes a crash that occurs in this case.

Fixes #254 