### PR TITLE
Use standard exit status code for usage errors

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -90,7 +90,7 @@ func mustParse(config Config, dest ...interface{}) *Parser {
 	p, err := NewParser(config, dest...)
 	if err != nil {
 		fmt.Fprintln(config.Out, err)
-		config.Exit(-1)
+		config.Exit(2)
 		return nil
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -703,7 +703,7 @@ func TestMustParseError(t *testing.T) {
 	os.Args = []string{"example"}
 	parser := MustParse(&args)
 	assert.Nil(t, parser)
-	assert.Equal(t, -1, exitCode)
+	assert.Equal(t, 2, exitCode)
 	assert.Contains(t, stdout.String(), "default values are not supported for slice or map fields")
 }
 
@@ -921,7 +921,7 @@ func TestParserMustParse(t *testing.T) {
 	}{
 		{name: "help", args: struct{}{}, cmdLine: []string{"--help"}, code: 0, output: "display this help and exit"},
 		{name: "version", args: versioned{}, cmdLine: []string{"--version"}, code: 0, output: "example 3.2.1"},
-		{name: "invalid", args: struct{}{}, cmdLine: []string{"invalid"}, code: -1, output: ""},
+		{name: "invalid", args: struct{}{}, cmdLine: []string{"invalid"}, code: 2, output: ""},
 	}
 
 	for _, tt := range tests {
@@ -1571,7 +1571,7 @@ func TestMustParseInvalidParser(t *testing.T) {
 	}
 	parser := mustParse(Config{Out: &stdout, Exit: exit}, &args)
 	assert.Nil(t, parser)
-	assert.Equal(t, -1, exitCode)
+	assert.Equal(t, 2, exitCode)
 }
 
 func TestMustParsePrintsHelp(t *testing.T) {

--- a/usage.go
+++ b/usage.go
@@ -9,13 +9,13 @@ import (
 // the width of the left column
 const colWidth = 25
 
-// Fail prints usage information to stderr and exits with non-zero status
+// Fail prints usage information to p.Config.Out and exits with status code 2.
 func (p *Parser) Fail(msg string) {
 	p.FailSubcommand(msg)
 }
 
-// FailSubcommand prints usage information for a specified subcommand to stderr,
-// then exits with non-zero status. To write usage information for a top-level
+// FailSubcommand prints usage information for a specified subcommand to p.Config.Out,
+// then exits with status code 2. To write usage information for a top-level
 // subcommand, provide just the name of that subcommand. To write usage
 // information for a subcommand that is nested under another subcommand, provide
 // a sequence of subcommand names starting with the top-level subcommand and so
@@ -27,7 +27,7 @@ func (p *Parser) FailSubcommand(msg string, subcommand ...string) error {
 	}
 
 	fmt.Fprintln(p.config.Out, "error:", msg)
-	p.config.Exit(-1)
+	p.config.Exit(2)
 	return nil
 }
 

--- a/usage_test.go
+++ b/usage_test.go
@@ -738,7 +738,7 @@ error: something went wrong
 	p.Fail("something went wrong")
 
 	assert.Equal(t, expectedStdout[1:], stdout.String())
-	assert.Equal(t, -1, exitCode)
+	assert.Equal(t, 2, exitCode)
 }
 
 func TestFailSubcommand(t *testing.T) {
@@ -761,7 +761,7 @@ error: something went wrong
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedStdout[1:], stdout.String())
-	assert.Equal(t, -1, exitCode)
+	assert.Equal(t, 2, exitCode)
 }
 
 type lengthOf struct {


### PR DESCRIPTION
The stdlib `flag` package (specifically [`ExitOnError`](https://pkg.go.dev/flag#ErrorHandling)) and most command line utilities use status code `2`.
I tried to find proper sources for common exit status codes, however these are the best I could find:

From: <https://stackoverflow.com/a/40484670>
> Exit status 0: success
> Exit status 1: "failure", as defined by the program
> Exit status 2: command line usage error

From: <https://tldp.org/LDP/abs/html/exitcodes.html>:
> 2 | Misuse of shell builtins (according to Bash documentation)

More importantly, currently using `-1` (which translates to 255) is actually documented as a bad choice in [`os.Exit`](https://pkg.go.dev/os#Exit):
> For portability, the status code should be in the range [0, 125].

Fixes #246 