### PR TITLE
Fix testable example output comment formatting

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -201,13 +201,12 @@ func Example_helpPlaceholder() {
 	MustParse(&args)
 
 	// output:
-
 	// Usage: example [--optimize LEVEL] [--maxjobs N] SRC [DST [DST ...]]
-
+	//
 	// Positional arguments:
 	//   SRC
 	//   DST
-
+	//
 	// Options:
 	//   --optimize LEVEL, -O LEVEL
 	//                          optimization level


### PR DESCRIPTION
The output of the testable example `Example_helpPlaceholder` is not working correctly due to wrong formatting.
Observe the example in [pkg.go.dev](https://pkg.go.dev/github.com/alexflint/go-arg#example-package-HelpPlaceholder) and note how the Output section is empty.

This simple PR fixes the formatting so the Output section works correctly.
I discovered this issue while running `golangci-lint` over the repository :)