### PR TITLE
Move writing program version from usage to help writer

### DIFF
--- a/usage.go
+++ b/usage.go
@@ -48,37 +48,15 @@ func (p *Parser) WriteUsageForSubcommand(w io.Writer, subcommand ...string) erro
 	}
 
 	var positionals, longOptions, shortOptions []*spec
-	var hasVersionOption bool
 	for _, spec := range cmd.specs {
 		switch {
 		case spec.positional:
 			positionals = append(positionals, spec)
 		case spec.long != "":
 			longOptions = append(longOptions, spec)
-			if spec.long == "version" {
-				hasVersionOption = true
-			}
 		case spec.short != "":
 			shortOptions = append(shortOptions, spec)
 		}
-	}
-
-	// make a list of ancestor commands so that we print with full context
-	// also determine if any ancestor has a version option spec
-	var ancestors []string
-	ancestor := cmd
-	for ancestor != nil {
-		for _, spec := range ancestor.specs {
-			if spec.long == "version" {
-				hasVersionOption = true
-			}
-		}
-		ancestors = append(ancestors, ancestor.name)
-		ancestor = ancestor.parent
-	}
-
-	if !hasVersionOption && p.version != "" {
-		fmt.Fprintln(w, p.version)
 	}
 
 	// print the beginning of the usage string
@@ -254,6 +232,11 @@ func (p *Parser) WriteHelpForSubcommand(w io.Writer, subcommand ...string) error
 	if p.description != "" {
 		fmt.Fprintln(w, p.description)
 	}
+
+	if !hasVersionOption && p.version != "" {
+		fmt.Fprintln(w, p.version)
+	}
+
 	p.WriteUsageForSubcommand(w, subcommand...)
 
 	// write the list of positionals

--- a/usage_test.go
+++ b/usage_test.go
@@ -237,7 +237,7 @@ func (versioned) Version() string {
 }
 
 func TestUsageWithVersion(t *testing.T) {
-	expectedUsage := "example 3.2.1\nUsage: example"
+	expectedUsage := "Usage: example"
 
 	expectedHelp := `
 example 3.2.1
@@ -322,7 +322,7 @@ type subcommand struct {
 }
 
 func TestUsageWithVersionAndSubcommand(t *testing.T) {
-	expectedUsage := "example 3.2.1\nUsage: example <command> [<args>]"
+	expectedUsage := "Usage: example <command> [<args>]"
 
 	expectedHelp := `
 example 3.2.1
@@ -353,7 +353,7 @@ Commands:
 	p.WriteUsage(&usage)
 	assert.Equal(t, expectedUsage, strings.TrimSpace(usage.String()))
 
-	expectedUsage = "example 3.2.1\nUsage: example cmd [--number NUMBER]"
+	expectedUsage = "Usage: example cmd [--number NUMBER]"
 
 	expectedHelp = `
 example 3.2.1


### PR DESCRIPTION
This simple PR fixes the linked issue below.
Writing the version on usage text is unexpected and confusing.

Resolves #193 