### PR TITLE
Add IgnoreUnknownCommands to handle unknown option as positional argument

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -127,6 +127,11 @@ type Config struct {
 	// default values, including pointers to sub commands
 	IgnoreDefault bool
 
+	// IgnoreUnknownCommands instructs the library not to fail when encountering
+	// unknown commands. Instead, it will ignore them and add them to the list
+	// of positionals.
+	IgnoreUnknownCommands bool
+
 	// StrictSubcommands intructs the library not to allow global commands after
 	// subcommand
 	StrictSubcommands bool
@@ -682,6 +687,10 @@ func (p *Parser) process(args []string) error {
 		// we expand subcommands so it is better not to use a map)
 		spec := findOption(specs, opt)
 		if spec == nil || opt == "" {
+			if p.config.IgnoreUnknownCommands {
+				positionals = append(positionals, arg)
+				continue
+			}
 			return fmt.Errorf("unknown argument %s", arg)
 		}
 		wasPresent[spec] = true

--- a/parse_test.go
+++ b/parse_test.go
@@ -1760,3 +1760,18 @@ func TestExitFunctionAndOutStreamGetFilledIn(t *testing.T) {
 	assert.NotNil(t, p.config.Exit) // go prohibits function pointer comparison
 	assert.Equal(t, p.config.Out, os.Stdout)
 }
+
+func TestIgnoreUnknownCommands(t *testing.T) {
+	var args struct {
+		Known bool     `arg:"--known"`
+		Args  []string `arg:"positional"`
+	}
+	p, err := NewParser(Config{IgnoreUnknownCommands: true}, &args)
+	require.NoError(t, err)
+
+	err = p.Parse([]string{"--known", "foo", "bar", "--unknown"})
+	require.NoError(t, err)
+
+	assert.True(t, args.Known)
+	assert.Equal(t, []string{"foo", "bar", "--unknown"}, args.Args)
+}


### PR DESCRIPTION
This feature allows unknown commands to be treated as positional arguments, which is useful for commands that need to collect trailing arguments, such as: `docker run some-image cmd --flag arg1 arg2 arg3`.​