### PR TITLE
Passing the no-more-options string "--" twice or more

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -615,7 +615,7 @@ func (p *Parser) process(args []string) error {
 	// must use explicit for loop, not range, because we manipulate i inside the loop
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if arg == "--" {
+		if arg == "--" && !allpositional {
 			allpositional = true
 			continue
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -609,6 +609,15 @@ func TestNoMoreOptionsBeforeHelp(t *testing.T) {
 	assert.NotEqual(t, ErrHelp, err)
 }
 
+func TestNoMoreOptionsTwice(t *testing.T) {
+	var args struct {
+		X []string `arg:"positional"`
+	}
+	err := parse("-- --", &args)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"--"}, args.X)
+}
+
 func TestHelpFlag(t *testing.T) {
 	var args struct {
 		Foo string


### PR DESCRIPTION
Passing the no-more-options string "--" twice or more should pass the second and subsequent ones through as positionals. This makes it possible to pass the string "--" as a positional:

```go
var args struct {
  X []string `arg:"positional"
}
arg.MustParse(&args)
```

```shell
./example -- test test2 -- test3  // args.X is [test, test2, --, test3]
```