### PR TITLE
Fix Missing Global Options

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -285,6 +285,13 @@ func NewParser(config Config, dests ...interface{}) (*Parser, error) {
 		}
 	}
 
+	// Set the parent of the subcommands to be the top-level command
+	// to make sure that global options work when there is more than one
+	// dest supplied.
+	for _, subcommand := range p.cmd.subcommands {
+		subcommand.parent = p.cmd
+	}
+
 	return &p, nil
 }
 


### PR DESCRIPTION
### Example
```go
package main

import "github.com/alexflint/go-arg"

type Subcmd1 struct{}
type Arg1 struct {
	Option1 string   `arg:"--opt1"`
	Subcmd  *Subcmd1 `arg:"subcommand:subcmd1"`
}
type Arg2 struct {
	Option2 string `arg:"--opt2"`
}

func main() {
	var arg1 Arg1
	var arg2 Arg2
	arg.MustParse(&arg1, &arg2)
}
```
*Output*
```
> tst --help
Usage: tst [--opt1 OPT1] [--opt2 OPT2] <command> [<args>]

Options:
  --opt1 OPT1
  --opt2 OPT2
  --help, -h             display this help and exit

Commands:
  subcmd1

> tst subcmd1 --help
Usage: tst subcmd1

Global options:
  --opt1 OPT1
  --help, -h             display this help and exit
  ```
  
 *Expected*
 ```
> tst subcmb1 --help
Usage: tst subcmd1

Global options:
  --opt1 OPT1
  --opt2 OPT2
  --help, -h             display this help and exit
  ```

When creating the command structure sub-commands don't get linked back to the root, so traversing the ancestors results in missing global options.