### PR TITLE
Parser config option to allow user control of `-h`

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -127,6 +127,10 @@ type Config struct {
 	// default values, including pointers to sub commands
 	IgnoreDefault bool
 
+	// IgnoreHelpVersion instructs the library to ignores its special handling
+	// of `-h` allowing the user to use it
+	IgnoreShortHelp bool
+
 	// StrictSubcommands intructs the library not to allow global commands after
 	// subcommand
 	StrictSubcommands bool
@@ -672,7 +676,11 @@ func (p *Parser) process(args []string) error {
 
 		// check for special --help and --version flags
 		switch arg {
-		case "-h", "--help":
+		case "-h":
+			if !p.config.IgnoreShortHelp {
+				return ErrHelp
+			}
+		case "--help":
 			return ErrHelp
 		case "--version":
 			if !hasVersionOption && p.version != "" {

--- a/parse_test.go
+++ b/parse_test.go
@@ -1779,3 +1779,17 @@ func TestExitFunctionAndOutStreamGetFilledIn(t *testing.T) {
 	assert.NotNil(t, p.config.Exit) // go prohibits function pointer comparison
 	assert.Equal(t, p.config.Out, os.Stdout)
 }
+
+func TestIgnoreShortHelp(t *testing.T) {
+	var args struct {
+		Host string `arg:"required,-h"`
+	}
+	_, err := parseWithEnv(Config{IgnoreShortHelp: true}, "-h 10.0.0.1", nil, &args)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1", args.Host)
+
+	// Check that help still works if you don't specify `IgnoreShortHelp`
+	_, err = parseWithEnv(Config{}, "-h 10.0.0.1", nil, &args)
+	require.Error(t, err)
+	require.Equal(t, ErrHelp.Error(), err.Error())
+}


### PR DESCRIPTION
Because I'm often wanting to use `-h` for "hostname", etc., the claiming of it by `go-arg` is annoying.  This PR adds a config option named `IgnoreShortHelp` which prevents `go-arg` from claiming `-h`.  `--help` is still left for `go-arg` to handle.