### PR TITLE
No more positionals after a positional slice or map

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1844,3 +1844,39 @@ func TestExitFunctionAndOutStreamGetFilledIn(t *testing.T) {
 	assert.NotNil(t, p.config.Exit) // go prohibits function pointer comparison
 	assert.Equal(t, p.config.Out, os.Stdout)
 }
+
+func TestNoPositionalsAfterPositionalSlice(t *testing.T) {
+	var args struct {
+		A []string `arg:"positional"`
+		B string   `arg:"positional"`
+	}
+	_, err := NewParser(Config{}, &args)
+	assert.Error(t, err)
+}
+
+func TestNoPositionalsAfterPositionalMap(t *testing.T) {
+	var args struct {
+		A map[int]float64 `arg:"positional"`
+		B string          `arg:"positional"`
+	}
+	_, err := NewParser(Config{}, &args)
+	assert.Error(t, err)
+}
+
+func TestNoPositionalSliceAfterPositionalSlice(t *testing.T) {
+	var args struct {
+		A []float64 `arg:"positional"`
+		B []float64 `arg:"positional"`
+	}
+	_, err := NewParser(Config{}, &args)
+	assert.Error(t, err)
+}
+
+func TestNoPositionalMapAfterPositionalMap(t *testing.T) {
+	var args struct {
+		A map[string]bool `arg:"positional"`
+		B map[int]bool    `arg:"positional"`
+	}
+	_, err := NewParser(Config{}, &args)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
With this PR, go-arg returns an error if you define more positional arguments after a positional slice or map. Such positional arguments cannot be populated by go-arg. This could break programs that define positional arguments after positional slices or maps, but for whatever reason never need them to be populated by go-arg.