### PR TITLE
feat: allow hiding a subcommand using "-" for help

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -33,9 +33,8 @@
 // (e.g. `./example -d`), and any tag string that starts with two hyphens is the long
 // form for the argument (instead of the field name).
 //
-// Other valid tag strings are `positional` and `required`.
+// Other valid tag strings are `positional`, `required`, and `hidden`. Using `hidden` will
+// exclude the field from help text and usage messages.
 //
 // Fields can be excluded from processing with `arg:"-"`.
-//
-// Explicitly setting `help:"-"` on a subcommand will hide it from the help output.
 package arg

--- a/parse.go
+++ b/parse.go
@@ -53,6 +53,7 @@ type spec struct {
 	positional    bool                // if true, this option will be looked for in the positional flags
 	separate      bool                // if true, each slice and map entry will have its own --flag
 	help          string              // the help text for this option
+	hidden        bool                // if true, this option will be hidden from help text
 	env           string              // the name of the environment variable for this option, or empty for none
 	defaultValue  reflect.Value       // default value for this option
 	defaultString string              // default value for this option, in string form to be displayed in help text
@@ -68,6 +69,7 @@ type command struct {
 	specs       []*spec
 	subcommands []*command
 	parent      *command
+	hidden      bool
 }
 
 // ErrHelp indicates that the builtin -h or --help were provided
@@ -386,6 +388,8 @@ func cmdFromStruct(name string, dest path, t reflect.Type, envPrefix string) (*c
 				spec.separate = true
 			case key == "help": // deprecated
 				spec.help = value
+			case key == "hidden":
+				spec.hidden = true
 			case key == "env":
 				// Use override name if provided
 				if value != "" {
@@ -436,6 +440,9 @@ func cmdFromStruct(name string, dest path, t reflect.Type, envPrefix string) (*c
 
 		// if this is a subcommand then we've done everything we need to do
 		if isSubcommand {
+			if spec.hidden {
+				cmd.subcommands[len(cmd.subcommands)-1].hidden = true
+			}
 			return false
 		}
 

--- a/usage.go
+++ b/usage.go
@@ -49,6 +49,9 @@ func (p *Parser) WriteUsageForSubcommand(w io.Writer, subcommand ...string) erro
 
 	var positionals, longOptions, shortOptions []*spec
 	for _, spec := range cmd.specs {
+		if spec.hidden {
+			continue
+		}
 		switch {
 		case spec.positional:
 			positionals = append(positionals, spec)
@@ -199,6 +202,10 @@ func (p *Parser) WriteHelpForSubcommand(w io.Writer, subcommand ...string) error
 	var positionals, longOptions, shortOptions, envOnlyOptions []*spec
 	var hasVersionOption bool
 	for _, spec := range cmd.specs {
+		if spec.hidden {
+			continue
+		}
+
 		switch {
 		case spec.positional:
 			positionals = append(positionals, spec)
@@ -293,7 +300,7 @@ func (p *Parser) WriteHelpForSubcommand(w io.Writer, subcommand ...string) error
 	if len(cmd.subcommands) > 0 {
 		fmt.Fprint(w, "\nCommands:\n")
 		for _, subcmd := range cmd.subcommands {
-			if subcmd.help == "-" {
+			if subcmd.hidden {
 				// skip this subcommand in the help message
 				continue
 			}

--- a/usage_test.go
+++ b/usage_test.go
@@ -1030,7 +1030,7 @@ Commands:
 
 	var args struct {
 		Remove *struct{} `arg:"subcommand:remove|rm|r" help:"remove something from somewhere"`
-		Simple *struct{} `arg:"subcommand" help:"-"`
+		Simple *struct{} `arg:"subcommand,hidden" help:"simple hidden subcommand"`
 		Stop   *struct{} `arg:"subcommand:halt|stop" help:"stop now"`
 	}
 	p, err := NewParser(Config{Program: "example"}, &args)
@@ -1054,6 +1054,30 @@ Options:
 
 	var args struct {
 		Foo string `arg:"positional" default:"bar" help:"this is a positional with a default"`
+	}
+
+	p, err := NewParser(Config{Program: "example"}, &args)
+	require.NoError(t, err)
+
+	var help bytes.Buffer
+	p.WriteHelp(&help)
+	assert.Equal(t, expectedHelp[1:], help.String())
+}
+
+func TestHelpShowsPositionalWithDefaultSkipHidden(t *testing.T) {
+	expectedHelp := `
+Usage: example [FOO]
+
+Positional arguments:
+  FOO                    this is a positional with a default [default: bar]
+
+Options:
+  --help, -h             display this help and exit
+`
+
+	var args struct {
+		Foo string `arg:"positional" default:"bar" help:"this is a positional with a default"`
+		Bar string `arg:"positional,hidden" default:"baz" help:"this is a hidden positional with a default"`
 	}
 
 	p, err := NewParser(Config{Program: "example"}, &args)


### PR DESCRIPTION
I ran into an issue where I wanted to be able to hide a subcommand from the help output (specifically for generating shell completions). 

It was *significantly* easier to add the feature to this library (thanks for the great library!) than it would have been to switch to a much heavier CLI framework library like cobra which would require a *ton* more boilerplate and the inability to leverage structs and struct tags.

This PR allows specifying that a subcommand should be excluded from the help output (i.e. hidden subcommand) by explicitly adding a struct tag of `help:"-"` similar to how `arg:"-"` will exlude a field from processing.

If there's a better way to indicate this, i'm more than happy to change it. This just seemed to be simple and also consistent!

Thanks again!